### PR TITLE
Wpf names are propely set using SvgObject Get and SetName methods

### DIFF
--- a/Source/SharpVectorConvertersWpf/LinkVisitor.cs
+++ b/Source/SharpVectorConvertersWpf/LinkVisitor.cs
@@ -183,7 +183,7 @@ namespace SharpVectors.Converters
                 WpfSvgPaint fillPaint = new WpfSvgPaint(context, _aggregatedFill, "fill");
                 Brush brush = fillPaint.GetBrush(false);
 
-                brush.SetValue(FrameworkElement.NameProperty, linkId + "_Brush");
+                SvgObject.SetName(brush, linkId + "_Brush");
 
                 GeometryDrawing drawing = new GeometryDrawing(brush, null, drawGeometry);
 

--- a/Source/SharpVectorConvertersWpf/XmlXamlWriter.cs
+++ b/Source/SharpVectorConvertersWpf/XmlXamlWriter.cs
@@ -422,7 +422,7 @@ namespace SharpVectors.Converters
             DependencyObject dep = obj as DependencyObject;
             if (dep != null)
             {
-                string nameValue = dep.GetValue(FrameworkElement.NameProperty) as string;
+                string nameValue = Runtime.SvgObject.GetName(dep);
                 if (!string.IsNullOrWhiteSpace(nameValue) && !(dep is FrameworkElement))
                 {
                     writer.WriteAttributeString("x", "Name", NamespaceCache.XamlNamespace, nameValue);

--- a/Source/SharpVectorRenderingWpf/Wpf/WpfARendering.cs
+++ b/Source/SharpVectorRenderingWpf/Wpf/WpfARendering.cs
@@ -109,7 +109,7 @@ namespace SharpVectors.Renderers.Wpf
                 string elementId = this.GetElementName();
                 if (!string.IsNullOrWhiteSpace(elementId) && !context.IsRegisteredId(elementId))
                 {
-                    _drawGroup.SetValue(FrameworkElement.NameProperty, elementId);
+                    SvgObject.SetName(_drawGroup, elementId);
 
                     context.RegisterId(elementId);
 

--- a/Source/SharpVectorRenderingWpf/Wpf/WpfDrawingContext.cs
+++ b/Source/SharpVectorRenderingWpf/Wpf/WpfDrawingContext.cs
@@ -397,7 +397,7 @@ namespace SharpVectors.Renderers.Wpf
                 string groupId = _linkVisitor.AggregatedLayerName;
                 if (!string.IsNullOrWhiteSpace(groupId))
                 {
-                    _linkDrawing.SetValue(FrameworkElement.NameProperty, groupId);
+                    Runtime.SvgObject.SetName(_linkDrawing, groupId);
                 }
 
                 linkVisitor.Initialize(_linkDrawing, this);

--- a/Source/SharpVectorRenderingWpf/Wpf/WpfGroupRendering.cs
+++ b/Source/SharpVectorRenderingWpf/Wpf/WpfGroupRendering.cs
@@ -38,7 +38,7 @@ namespace SharpVectors.Renderers.Wpf
             string elementId = this.GetElementName();
             if (!string.IsNullOrWhiteSpace(elementId) && !context.IsRegisteredId(elementId))
             {
-                _drawGroup.SetValue(FrameworkElement.NameProperty, elementId);
+                SvgObject.SetName(_drawGroup, elementId);
 
                 context.RegisterId(elementId);
 

--- a/Source/SharpVectorRenderingWpf/Wpf/WpfMarkerRendering.cs
+++ b/Source/SharpVectorRenderingWpf/Wpf/WpfMarkerRendering.cs
@@ -68,7 +68,7 @@ namespace SharpVectors.Renderers.Wpf
             string elementId = this.GetElementName();
             if (!string.IsNullOrWhiteSpace(elementId) && !context.IsRegisteredId(elementId))
             {
-                _drawGroup.SetValue(FrameworkElement.NameProperty, elementId);
+                SvgObject.SetName(_drawGroup, elementId);
 
                 context.RegisterId(elementId);
 

--- a/Source/SharpVectorRenderingWpf/Wpf/WpfPathRendering.cs
+++ b/Source/SharpVectorRenderingWpf/Wpf/WpfPathRendering.cs
@@ -131,7 +131,7 @@ namespace SharpVectors.Renderers.Wpf
 
                     if (!string.IsNullOrWhiteSpace(elementId) && !context.IsRegisteredId(elementId))
                     {
-                        drawing.SetValue(FrameworkElement.NameProperty, elementId);
+                        SvgObject.SetName(drawing, elementId);
 
                         context.RegisterId(elementId);
 

--- a/Source/SharpVectorRenderingWpf/Wpf/WpfSvgRendering.cs
+++ b/Source/SharpVectorRenderingWpf/Wpf/WpfSvgRendering.cs
@@ -73,7 +73,7 @@ namespace SharpVectors.Renderers.Wpf
                 }
                 if (currentGroup == context.Root && !context.IsFragment)
                 {
-                    _drawGroup.SetValue(FrameworkElement.NameProperty, SvgObject.DrawLayer);
+                    SvgObject.SetName(_drawGroup, SvgObject.DrawLayer);
                     if (context.IncludeRuntime)
                     {
                         SvgLink.SetKey(_drawGroup, SvgObject.DrawLayer);

--- a/Source/SharpVectorRenderingWpf/Wpf/WpfTextRendering.cs
+++ b/Source/SharpVectorRenderingWpf/Wpf/WpfTextRendering.cs
@@ -146,7 +146,7 @@ namespace SharpVectors.Renderers.Wpf
             string elementId = this.GetElementName();
             if (!string.IsNullOrWhiteSpace(elementId) && !context.IsRegisteredId(elementId))
             {
-                _drawGroup.SetValue(FrameworkElement.NameProperty, elementId);
+                SvgObject.SetName(_drawGroup, elementId);
 
                 context.RegisterId(elementId);
 

--- a/Source/SharpVectorRuntimeWpf/SvgAnimationLayer.cs
+++ b/Source/SharpVectorRuntimeWpf/SvgAnimationLayer.cs
@@ -166,7 +166,7 @@ namespace SharpVectors.Runtime
                 if (childGroup != null)
                 {
                     string groupName = SvgLink.GetKey(childGroup);
-                    //string groupName = childGroup.GetValue(FrameworkElement.NameProperty) as string;
+                    //string groupName = SvgObject.GetName(childGroup);
                     if (string.IsNullOrWhiteSpace(groupName))
                     {
                         if (childGroup.Children != null && childGroup.Children.Count == 1)
@@ -253,7 +253,7 @@ namespace SharpVectors.Runtime
             {
                 if (_hitVisual != null)
                 {
-                    itemName = _hitVisual.GetValue(FrameworkElement.NameProperty) as string;
+                    itemName = SvgObject.GetName(_hitVisual);
                     if (itemName == null)
                     {
                         _hitVisual = null;
@@ -289,7 +289,7 @@ namespace SharpVectors.Runtime
 
                 if (_hitVisual != null)
                 {
-                    itemName = _hitVisual.GetValue(FrameworkElement.NameProperty) as string;
+                    itemName = SvgObject.GetName(_hitVisual);
                     if (itemName == null)
                     {
                         _hitVisual = null;
@@ -306,7 +306,7 @@ namespace SharpVectors.Runtime
                     _hitVisual = null;
                 }
 
-                itemName = hitVisual.GetValue(FrameworkElement.NameProperty) as string;
+                itemName = SvgObject.GetName(hitVisual);
                 if (itemName == null)
                 {
                     return false;
@@ -375,7 +375,7 @@ namespace SharpVectors.Runtime
                 return true;
             }
 
-            string itemName = visual.GetValue(FrameworkElement.NameProperty) as string;
+            string itemName = SvgObject.GetName(visual);
             if (itemName == null)
             {
                 if (_tooltip != null)
@@ -408,7 +408,7 @@ namespace SharpVectors.Runtime
             }
             if (_selectedVisual != null)
             {
-                itemName = _selectedVisual.GetValue(FrameworkElement.NameProperty) as string;
+                itemName = SvgObject.GetName(_selectedVisual);
                 if (itemName == null)
                 {
                     return false;
@@ -432,7 +432,7 @@ namespace SharpVectors.Runtime
 
             if (e.ChangedButton == MouseButton.Left)
             {
-                string brushName = brush.GetValue(FrameworkElement.NameProperty) as string;
+                string brushName = SvgObject.GetName(brush);
                 if (!string.IsNullOrWhiteSpace(brushName))
                 {
                     SvgLinkAction linkAction = SvgLink.GetAction(visual);
@@ -464,7 +464,7 @@ namespace SharpVectors.Runtime
                 return false;
             }
 
-            string itemName = _hitVisual.GetValue(FrameworkElement.NameProperty) as string;
+            string itemName = SvgObject.GetName(_hitVisual);
             if (itemName == null)
             {
                 _hitVisual = null;
@@ -543,7 +543,7 @@ namespace SharpVectors.Runtime
                 textBrush = new SolidColorBrush(_colorLink);
             }
             string brushName = name + "_Brush";
-            textBrush.SetValue(FrameworkElement.NameProperty, brushName);
+            SvgObject.SetName(textBrush, brushName);
 
             DrawingCollection drawings = group.Children;
             int itemCount = drawings != null ? drawings.Count : 0;
@@ -614,7 +614,7 @@ namespace SharpVectors.Runtime
                     {
                         groupName = SvgObject.GetId(drawGroup);
                     }
-                    //string groupName = childGroup.GetValue(FrameworkElement.NameProperty) as string;
+                    //string groupName = SvgObject.GetName(childGroup);
                     if (string.IsNullOrWhiteSpace(groupName))
                     {
                         LoadLayerGroup(drawGroup);
@@ -669,7 +669,7 @@ namespace SharpVectors.Runtime
                     {
                         groupName = SvgObject.GetId(drawGroup);
                     }
-                    //string groupName = childGroup.GetValue(FrameworkElement.NameProperty) as string;
+                    //string groupName = SvgObject.GetName(childGroup);
                     if (string.IsNullOrWhiteSpace(groupName))
                     {
                         LoadLayerGroup(drawGroup);

--- a/Source/SharpVectorRuntimeWpf/SvgDrawingCanvas.cs
+++ b/Source/SharpVectorRuntimeWpf/SvgDrawingCanvas.cs
@@ -270,7 +270,7 @@ namespace SharpVectors.Runtime
             for (int i = 0; i < drawings.Count; i++)
             {
                 Drawing drawing = drawings[i];
-                //string drawingName = drawing.GetValue(FrameworkElement.NameProperty) as string;
+                //string drawingName = SvgObject.GetName(drawing);
                 string drawingName = SvgLink.GetKey(drawing);
                 if (!string.IsNullOrWhiteSpace(drawingName) &&
                     string.Equals(drawingName, SvgObject.DrawLayer))
@@ -412,7 +412,7 @@ namespace SharpVectors.Runtime
                 return;
             }
 
-            string itemName = visual.GetValue(FrameworkElement.NameProperty) as string;
+            string itemName = SvgObject.GetName(visual);
             if (itemName == null)
             {
                 if (_tooltip != null)
@@ -441,7 +441,7 @@ namespace SharpVectors.Runtime
 
             //if (e.ChangedButton == MouseButton.Left)
             //{
-            //    string brushName = brush.GetValue(FrameworkElement.NameProperty) as string;
+            //    string brushName = SvgObject.GetName(visual);
             //    if (!string.IsNullOrWhiteSpace(brushName))
             //    {
             //        SvgLinkAction linkAction = SvgLink.GetLinkAction(visual);
@@ -480,7 +480,7 @@ namespace SharpVectors.Runtime
 
                 if (_hitVisual != null)
                 {
-                    //itemName = _hitVisual.GetValue(FrameworkElement.NameProperty) as string;
+                    //itemName = SvgObject.GetName(_hitVisual);
                     //if (itemName == null)
                     //{
                     //    _hitVisual = null;
@@ -513,7 +513,7 @@ namespace SharpVectors.Runtime
 
                 if (_hitVisual != null)
                 {
-                    //itemName = _hitVisual.GetValue(FrameworkElement.NameProperty) as string;
+                    //itemName = SvgObject.GetName(_hitVisual);
                     //if (itemName == null)
                     //{
                     //    _hitVisual = null;
@@ -527,7 +527,7 @@ namespace SharpVectors.Runtime
                     _hitVisual = null;
                 }
 
-                //itemName = hitVisual.GetValue(FrameworkElement.NameProperty) as string;
+                //itemName = SvgObject.GetName(hitVisual);
                 //if (itemName == null)
                 //{
                 //    return;
@@ -597,7 +597,7 @@ namespace SharpVectors.Runtime
                 return;
             }
 
-            string itemName = _hitVisual.GetValue(FrameworkElement.NameProperty) as string;
+            string itemName = SvgObject.GetName(_hitVisual);
             if (itemName == null)
             {
                 _hitVisual = null;

--- a/Source/SharpVectorRuntimeWpf/SvgImage.cs
+++ b/Source/SharpVectorRuntimeWpf/SvgImage.cs
@@ -54,7 +54,7 @@ namespace SharpVectors.Runtime
 
             if (namedObject != null)
             {   
-                namedObject.SetValue(FrameworkElement.NameProperty, name);
+                SvgObject.SetName(namedObject, name);
             }
         }
 

--- a/Source/SharpVectorRuntimeWpf/SvgObject.cs
+++ b/Source/SharpVectorRuntimeWpf/SvgObject.cs
@@ -32,6 +32,25 @@ namespace SharpVectors.Runtime
 
         #region Public Methods
 
+        public static void SetName(DependencyObject element, string name)
+        {
+            if (!string.IsNullOrEmpty(name) && char.IsDigit(name[0]))
+            {
+                name = "_" + name;
+            }
+            element.SetValue(FrameworkElement.NameProperty, name);
+        }
+
+        public static string GetName(DependencyObject element)
+        {
+            string name = element.GetValue(FrameworkElement.NameProperty) as string;
+            if (!string.IsNullOrEmpty(name) && name.StartsWith("_"))
+            {
+                name = name.Remove(0, 1);
+            }
+            return name;
+        }
+
         public static void SetId(DependencyObject element, string value)
         {
             element.SetValue(IdProperty, value);


### PR DESCRIPTION
Because the FrameworkElement Name property generally follows the rules of C#/VB.NET identifiers (i.e. fields). Based on the documentation:

> The string values used for Name have some restrictions, as imposed by the underlying x:Name Directive defined by the XAML specification. Most notably, a Name must start with a letter or the underscore character (_), and must contain only letters, digits, or underscores.

That's why I have replaced all sets and gets of the FrameworkElement.NameProperty with a convenience method on SvgObject that checks and fixes that