### PR TITLE
Svg rendering using WPF shapes

### DIFF
--- a/Samples/WpfTestSvgSample/DrawingPage.xaml.cs
+++ b/Samples/WpfTestSvgSample/DrawingPage.xaml.cs
@@ -14,7 +14,7 @@ namespace WpfTestSvgSample
     /// <summary>
     /// Interaction logic for DrawingPage.xaml
     /// </summary>
-    public partial class DrawingPage : Page
+    public partial class DrawingPage : Page, IDrawingPage
     {
         #region Private Fields
 

--- a/Samples/WpfTestSvgSample/IDrawingPage.cs
+++ b/Samples/WpfTestSvgSample/IDrawingPage.cs
@@ -1,0 +1,13 @@
+﻿namespace WpfTestSvgSample
+{
+    interface IDrawingPage
+    {
+        bool SaveXaml { get; set; }
+        string XamlDrawingDir { get; set; }
+
+        bool LoadDocument(string svgFilePath);
+        void UnloadDocument();
+        bool SaveDocument(string fileName);
+        void PageSelected(bool isSelected);
+    }
+}

--- a/Samples/WpfTestSvgSample/MainWindow.xaml
+++ b/Samples/WpfTestSvgSample/MainWindow.xaml
@@ -43,7 +43,7 @@
                           HorizontalAlignment="Center" Width="6" VerticalAlignment="Stretch"/>
                 <TabControl Name="contentsTab"  Margin="6" Grid.Row="0" Grid.Column="2">
                     <TabItem Name="tabDrawing" Header="Drawing" GotFocus="OnTabItemGotFocus">
-                        <Frame Name="frameDrawing" Source="DrawingPage.xaml"/>
+                        <Frame Name="frameDrawing" Source="ShapeDrawingPage.xaml"/>
                     </TabItem>
                     <TabItem Name="tabXamlOutput" GotFocus="OnTabItemGotFocus">
                         <TabItem.Header>

--- a/Samples/WpfTestSvgSample/MainWindow.xaml.cs
+++ b/Samples/WpfTestSvgSample/MainWindow.xaml.cs
@@ -43,7 +43,7 @@ namespace WpfTestSvgSample
 
         private SvgPage _svgPage;
         private XamlPage _xamlPage;
-        private DrawingPage _drawingPage;
+        private IDrawingPage _drawingPage;
 
         private BitmapImage _folderClose;
         private BitmapImage _folderOpen;
@@ -133,7 +133,7 @@ namespace WpfTestSvgSample
             // Retrieve the display pages...
             _svgPage     = frameSvgInput.Content as SvgPage;
             _xamlPage    = frameXamlOutput.Content as XamlPage;
-            _drawingPage = frameDrawing.Content as DrawingPage;
+            _drawingPage = frameDrawing.Content as IDrawingPage;
 
             if (_drawingPage != null)
             {

--- a/Samples/WpfTestSvgSample/ShapeDrawingPage.xaml
+++ b/Samples/WpfTestSvgSample/ShapeDrawingPage.xaml
@@ -1,0 +1,108 @@
+﻿<Page x:Class="WpfTestSvgSample.ShapeDrawingPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:svg="http://sharpvectors.codeplex.com/runtime/"
+      xmlns:local="clr-namespace:WpfTestSvgSample"
+      xmlns:wpfShapeRendering="clr-namespace:SharpVectors.Renderers.Wpf.Shape;assembly=SharpVectors.Rendering.Wpf"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="800"
+      Title="ShapeDrawingPage" Background="White"
+      FocusManager.FocusedElement="{Binding ElementName=canvasScroller}">
+    <Page.Resources>
+        <!-- UI commands. -->
+        <RoutedUICommand x:Key="Commands.ZoomOut" />
+        <RoutedUICommand x:Key="Commands.ZoomIn" />
+        <RoutedUICommand x:Key="Commands.Fill" />
+
+        <!-- This converts from a scale value to a percentage value.
+        It is used to convert the value of 'ContentScale' to the percentage zoom level that is displayed in the UI. -->
+        <local:ScaleToPercentConverter x:Key="scaleToPercentConverter"/>
+    </Page.Resources>
+
+    <Page.InputBindings>
+        <!-- Bind keys to commands. -->
+        <KeyBinding Key="Minus" Command="{StaticResource Commands.ZoomOut}"/>
+        <KeyBinding Key="Plus" Command="{StaticResource Commands.ZoomIn}"/>
+    </Page.InputBindings>
+
+    <Page.CommandBindings>
+        <!-- Bind commands to event handlers. -->
+        <CommandBinding Command="{StaticResource Commands.ZoomOut}" 
+            Executed="OnZoomOut"/>
+        <CommandBinding Command="{StaticResource Commands.ZoomIn}" 
+            Executed="OnZoomIn"/>
+        <CommandBinding Command="{StaticResource Commands.Fill}" 
+            Executed="OnZoomFit"/>
+    </Page.CommandBindings>
+
+    <DockPanel LastChildFill="True">
+        <ToolBar DockPanel.Dock="Top" Height="32">
+            <ToolBar.Resources>
+                <Style TargetType="{x:Type Image}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type ButtonBase}, AncestorLevel=1}, Path=IsEnabled}" Value="False">
+                            <Setter Property="Opacity" Value="0.30" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </ToolBar.Resources>
+            <Button Click="OnZoomIn" Height="24" Width="24" ToolTip="Zoom In">
+                <Image Source="Images/ZoomIn.png" Height="16"/>
+            </Button>
+            <Button Click="OnResetZoom" Height="24" Width="24" ToolTip="Reset Zoom">
+                <Image Source="Images/ZoomReset.png" Height="16"/>
+            </Button>
+            <Button Click="OnZoomOut" Height="24" Width="24" ToolTip="Zoom Out">
+                <Image Source="Images/ZoomOut.png" Height="16"/>
+            </Button>
+            <Separator/>
+
+            <!-- This is the label that shows what the current zoom level
+            is while zooming in and out. -->
+            <TextBlock MinWidth="24" VerticalAlignment="Center"
+                HorizontalAlignment="Right" TextAlignment="Right"
+                Text="{Binding ElementName=zoomPanControl, Path=ContentScale, Converter={StaticResource scaleToPercentConverter}}"/>
+            <TextBlock VerticalAlignment="Center" Text="%"/>
+
+            <!-- Slider to change the current zoom level. -->
+            <Slider Name="zoomSlider" Width="250" Padding="0" Minimum="10" LargeChange="20" 
+                TickFrequency="10" Maximum="500" SmallChange="10" TickPlacement="TopLeft"
+                Value="{Binding ElementName=zoomPanControl, Path=ContentScale, Converter={StaticResource scaleToPercentConverter}}"/>
+            <!-- The fill button.  Causes the content to be scaled so that it fits in the viewport.-->
+            <Button Height="24" Width="24" Click="OnZoomFitClick" Content="Fit"/>
+
+            <Separator/>
+            <ToggleButton Name="tbbPanning" Click="OnPanClick" Height="24" Width="24" ToolTip="Toggle Panning">
+                <Image Source="Images/Panning.png" Height="16"/>
+            </ToggleButton>
+        </ToolBar>
+
+        <!-- Wrap the ZoomAndPanControl in a ScrollViewer.
+        When the scaled content that is displayed in ZoomAndPanControl is larger than the viewport onto the content
+        ScrollViewer's scrollbars can be used to manipulate the offset of the viewport. -->
+        <ScrollViewer x:Name="canvasScroller" CanContentScroll="True" Padding="4"
+            VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Visible" AllowDrop="True">
+
+            <!-- This is the control that handles zooming and panning. -->
+            <svg:ZoomPanControl x:Name="zoomPanControl" Background="LightGray"
+                MouseDown="OnZoomPanMouseDown" MouseUp="OnZoomPanMouseUp"
+                MouseMove="OnZoomPanMouseMove" MouseWheel="OnZoomPanMouseWheel">
+
+                <Canvas Name="LayerContainer" Width="{Binding ElementName=svgViewer, Path=ActualWidth}"
+                         Height="{Binding ElementName=svgViewer, Path=ActualHeight}">
+                    <!-- This Canvas is the content that is displayed by the ZoomPanControl.
+                    Width and Height determine the size of the content. -->
+                    <wpfShapeRendering:SvgShapeViewer x:Name="svgViewer" Background="White"/>
+
+                    <Canvas Name="UserLayer" Width="{Binding ElementName=svgViewer, Path=ActualWidth}"
+                             Height="{Binding ElementName=svgViewer, Path=ActualHeight}">
+                    </Canvas>
+                </Canvas>
+
+            </svg:ZoomPanControl>
+
+        </ScrollViewer>
+    </DockPanel>
+</Page>

--- a/Samples/WpfTestSvgSample/ShapeDrawingPage.xaml.cs
+++ b/Samples/WpfTestSvgSample/ShapeDrawingPage.xaml.cs
@@ -1,0 +1,442 @@
+﻿using System;
+using System.IO;
+
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Controls;
+
+using SharpVectors.Renderers.Wpf;
+using SharpVectors.Converters;
+
+namespace WpfTestSvgSample
+{
+    /// <summary>
+    /// Interaction logic for ShapeDrawingPage.xaml
+    /// </summary>
+    public partial class ShapeDrawingPage : Page, IDrawingPage
+    {
+        #region Private Fields
+
+        private bool _saveXaml;
+
+        private string _drawingDir;
+        private DirectoryInfo _directoryInfo;
+
+        private FileSvgReader _fileReader;
+        private WpfDrawingSettings _wpfSettings;
+
+        private DirectoryInfo _workingDir;
+
+        /// <summary>
+        /// Specifies the current state of the mouse handling logic.
+        /// </summary>
+        private MouseHandlingMode mouseHandlingMode;
+
+        /// <summary>
+        /// The point that was clicked relative to the ZoomAndPanControl.
+        /// </summary>
+        private Point origZoomAndPanControlMouseDownPoint;
+
+        /// <summary>
+        /// The point that was clicked relative to the content that is contained within the ZoomAndPanControl.
+        /// </summary>
+        private Point origContentMouseDownPoint;
+
+        /// <summary>
+        /// Records which mouse button clicked during mouse dragging.
+        /// </summary>
+        private MouseButton mouseButtonDown;
+
+        #endregion
+
+        #region Constructors and Destructor
+
+        public ShapeDrawingPage()
+        {
+            InitializeComponent();
+
+            _saveXaml = true;
+            _wpfSettings = new WpfDrawingSettings();
+            _wpfSettings.CultureInfo = _wpfSettings.NeutralCultureInfo;
+
+            _fileReader = new FileSvgReader(_wpfSettings);
+            _fileReader.SaveXaml = _saveXaml;
+            _fileReader.SaveZaml = false;
+
+            mouseHandlingMode = MouseHandlingMode.None;
+
+            string workDir = Path.Combine(Path.GetDirectoryName(
+                System.Reflection.Assembly.GetExecutingAssembly().Location), "XamlDrawings");
+
+            _workingDir = new DirectoryInfo(workDir);
+
+            this.Loaded += new RoutedEventHandler(OnPageLoaded);
+        }
+
+        #endregion      
+
+        #region Public Properties
+
+        public string XamlDrawingDir
+        {
+            get
+            {
+                return _drawingDir;
+            }
+            set
+            {
+                _drawingDir = value;
+
+                if (!string.IsNullOrWhiteSpace(_drawingDir))
+                {
+                    _directoryInfo = new DirectoryInfo(_drawingDir);
+
+                    if (_fileReader != null)
+                    {
+                        _fileReader.SaveXaml = Directory.Exists(_drawingDir);
+                    }
+                }
+            }
+        }
+
+        public bool SaveXaml
+        {
+            get
+            {
+                return _saveXaml;
+            }
+            set
+            {
+                _saveXaml = value;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public bool LoadDocument(string svgFilePath)
+        {
+            if (string.IsNullOrWhiteSpace(svgFilePath) || !File.Exists(svgFilePath))
+            {
+                return false;
+            }
+
+            DirectoryInfo workingDir = _workingDir;
+            if (_directoryInfo != null)
+            {
+                workingDir = _directoryInfo;
+            }
+
+            //double currentZoom = zoomSlider.Value;
+
+            svgViewer.UnloadDiagrams();
+
+            //zoomSlider.Value = 1.0;
+
+            string fileExt = Path.GetExtension(svgFilePath);
+
+            if (String.Equals(fileExt, ".svgz", StringComparison.OrdinalIgnoreCase) ||
+                String.Equals(fileExt, ".svg", StringComparison.OrdinalIgnoreCase))
+            {
+                this.svgViewer.Source = svgFilePath;
+
+                Rect bounds = svgViewer.Bounds;
+                if (bounds.IsEmpty)
+                {
+                    bounds = new Rect(0, 0,
+                        canvasScroller.ActualWidth, canvasScroller.ActualHeight);
+                }
+                zoomPanControl.AnimatedZoomTo(bounds);
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public void UnloadDocument()
+        {
+            if (svgViewer != null)
+            {
+                svgViewer.UnloadDiagrams();
+            }
+        }
+
+        public bool SaveDocument(string fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                return false;
+            }
+
+            if (_fileReader == null || _fileReader.Drawing == null)
+            {
+                return false;
+            }
+
+            return _fileReader.Save(fileName, true, false);
+        }
+
+        public void PageSelected(bool isSelected)
+        {
+        }
+
+        #endregion
+
+        #region Protected Methods
+
+        protected override void OnInitialized(EventArgs e)
+        {
+            base.OnInitialized(e);
+        }
+
+        #endregion
+
+        #region Private Event Handlers
+
+        private void OnPageLoaded(object sender, RoutedEventArgs e)
+        {
+            zoomSlider.Value = 100;
+
+            if (zoomPanControl != null)
+            {
+                zoomPanControl.IsMouseWheelScrollingEnabled = true;
+            }
+        }
+
+        private void OnZoomSliderValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (zoomPanControl != null)
+            {
+                zoomPanControl.AnimatedZoomTo(zoomSlider.Value / 100.0);
+            }
+        }
+
+        private void OnZoomInClick(object sender, RoutedEventArgs e)
+        {
+            this.ZoomIn();
+        }
+
+        private void OnZoomOutClick(object sender, RoutedEventArgs e)
+        {
+            this.ZoomOut();
+        }
+
+        private void OnResetZoom(object sender, RoutedEventArgs e)
+        {
+            if (zoomPanControl == null)
+            {
+                return;
+            }
+
+            zoomPanControl.ContentScale = 1.0;
+        }
+
+        /// <summary>
+        /// The 'ZoomIn' command (bound to the plus key) was executed.
+        /// </summary>
+        private void OnZoomFitClick(object sender, RoutedEventArgs e)
+        {
+            if (svgViewer == null || zoomPanControl == null)
+            {
+                return;
+            }
+
+            Rect bounds = svgViewer.Bounds;
+
+            //Rect rect = new Rect(0, 0,
+            //    mainFrame.RenderSize.Width, mainFrame.RenderSize.Height);
+            //Rect rect = new Rect(0, 0,
+            //    bounds.Width, bounds.Height);
+            if (bounds.IsEmpty)
+            {
+                bounds = new Rect(0, 0,
+                    canvasScroller.ActualWidth, canvasScroller.ActualHeight);
+            }
+            zoomPanControl.AnimatedZoomTo(bounds);
+        }
+
+        private void OnPanClick(object sender, RoutedEventArgs e)
+        {
+            //if (drawScrollView == null)
+            //{
+            //    return;
+            //}
+
+            //drawScrollView.ZoomableCanvas.IsPanning = 
+            //    (tbbPanning.IsChecked != null && tbbPanning.IsChecked.Value);
+        }
+
+        #region Private Zoom Panel Handlers
+
+        /// <summary>
+        /// Event raised on mouse down in the ZoomAndPanControl.
+        /// </summary>
+        private void OnZoomPanMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            svgViewer.Focus();
+            Keyboard.Focus(svgViewer);
+
+            mouseButtonDown = e.ChangedButton;
+            origZoomAndPanControlMouseDownPoint = e.GetPosition(zoomPanControl);
+            origContentMouseDownPoint = e.GetPosition(svgViewer);
+
+            if ((Keyboard.Modifiers & ModifierKeys.Shift) != 0 &&
+                (e.ChangedButton == MouseButton.Left ||
+                 e.ChangedButton == MouseButton.Right))
+            {
+                // Shift + left- or right-down initiates zooming mode.
+                mouseHandlingMode = MouseHandlingMode.Zooming;
+            }
+            else if (mouseButtonDown == MouseButton.Left)
+            {
+                // Just a plain old left-down initiates panning mode.
+                mouseHandlingMode = MouseHandlingMode.Panning;
+            }
+
+            if (mouseHandlingMode != MouseHandlingMode.None)
+            {
+                // Capture the mouse so that we eventually receive the mouse up event.
+                zoomPanControl.CaptureMouse();
+                e.Handled = true;
+            }
+        }
+
+        /// <summary>
+        /// Event raised on mouse up in the ZoomAndPanControl.
+        /// </summary>
+        private void OnZoomPanMouseUp(object sender, MouseButtonEventArgs e)
+        {
+            if (mouseHandlingMode != MouseHandlingMode.None)
+            {
+                if (mouseHandlingMode == MouseHandlingMode.Zooming)
+                {
+                    if (mouseButtonDown == MouseButton.Left)
+                    {
+                        // Shift + left-click zooms in on the content.
+                        ZoomIn();
+                    }
+                    else if (mouseButtonDown == MouseButton.Right)
+                    {
+                        // Shift + left-click zooms out from the content.
+                        ZoomOut();
+                    }
+                }
+
+                zoomPanControl.ReleaseMouseCapture();
+                mouseHandlingMode = MouseHandlingMode.None;
+                e.Handled = true;
+            }
+        }
+
+        /// <summary>
+        /// Event raised on mouse move in the ZoomAndPanControl.
+        /// </summary>
+        private void OnZoomPanMouseMove(object sender, MouseEventArgs e)
+        {
+            if (mouseHandlingMode == MouseHandlingMode.Panning)
+            {
+                //
+                // The user is left-dragging the mouse.
+                // Pan the viewport by the appropriate amount.
+                //
+                Point curContentMousePoint = e.GetPosition(svgViewer);
+                Vector dragOffset = curContentMousePoint - origContentMouseDownPoint;
+
+                zoomPanControl.ContentOffsetX -= dragOffset.X;
+                zoomPanControl.ContentOffsetY -= dragOffset.Y;
+
+                e.Handled = true;
+            }
+        }
+
+        /// <summary>
+        /// Event raised by rotating the mouse wheel
+        /// </summary>
+        private void OnZoomPanMouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            e.Handled = true;
+
+            if (e.Delta > 0)
+            {
+                ZoomIn();
+            }
+            else if (e.Delta < 0)
+            {
+                ZoomOut();
+            }
+        }
+
+        /// <summary>
+        /// The 'ZoomIn' command (bound to the plus key) was executed.
+        /// </summary>
+        private void OnZoomFit(object sender, RoutedEventArgs e)
+        {
+            if (svgViewer == null || zoomPanControl == null)
+            {
+                return;
+            }
+
+            Rect bounds = svgViewer.Bounds;
+
+            //Rect rect = new Rect(0, 0,
+            //    mainFrame.RenderSize.Width, mainFrame.RenderSize.Height);
+            //Rect rect = new Rect(0, 0,
+            //    bounds.Width, bounds.Height);
+            if (bounds.IsEmpty)
+            {
+                bounds = new Rect(0, 0,
+                    canvasScroller.ActualWidth, canvasScroller.ActualHeight);
+            }
+            zoomPanControl.AnimatedZoomTo(bounds);
+        }
+
+        /// <summary>
+        /// The 'ZoomIn' command (bound to the plus key) was executed.
+        /// </summary>
+        private void OnZoomIn(object sender, RoutedEventArgs e)
+        {
+            ZoomIn();
+        }
+
+        /// <summary>
+        /// The 'ZoomOut' command (bound to the minus key) was executed.
+        /// </summary>
+        private void OnZoomOut(object sender, RoutedEventArgs e)
+        {
+            ZoomOut();
+        }
+
+        /// <summary>
+        /// Zoom the viewport out by a small increment.
+        /// </summary>
+        private void ZoomOut()
+        {
+            if (zoomPanControl == null)
+            {
+                return;
+            }
+
+            zoomPanControl.ContentScale -= 0.1;
+        }
+
+        /// <summary>
+        /// Zoom the viewport in by a small increment.
+        /// </summary>
+        private void ZoomIn()
+        {
+            if (zoomPanControl == null)
+            {
+                return;
+            }
+
+            zoomPanControl.ContentScale += 0.1;
+        }
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/Samples/WpfTestSvgSample/WpfTestSvgSample.csproj
+++ b/Samples/WpfTestSvgSample/WpfTestSvgSample.csproj
@@ -40,20 +40,20 @@
     <Reference Include="ICSharpCode.AvalonEdit">
       <HintPath>..\..\Libraries\ICSharpCode.AvalonEdit.dll</HintPath>
     </Reference>
-    <Reference Include="ReachFramework"/>
+    <Reference Include="ReachFramework" />
     <Reference Include="System" />
-    <Reference Include="System.Core"/>
-    <Reference Include="System.Printing"/>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Printing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
-    <Reference Include="System.Xml.Linq"/>
-    <Reference Include="System.Data.DataSetExtensions"/>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="UIAutomationProvider"/>
-    <Reference Include="WindowsBase"/>
-    <Reference Include="PresentationCore"/>
-    <Reference Include="PresentationFramework"/>
+    <Reference Include="UIAutomationProvider" />
+    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -80,6 +80,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="ShapeDrawingPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="SvgPage.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -96,6 +100,7 @@
       <DependentUpon>App.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="IDrawingPage.cs" />
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -123,6 +128,9 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
     <Compile Include="ScaleToPercentConverter.cs" />
+    <Compile Include="ShapeDrawingPage.xaml.cs">
+      <DependentUpon>ShapeDrawingPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="SvgPage.xaml.cs">
       <DependentUpon>SvgPage.xaml</DependentUpon>
     </Compile>

--- a/Source/SharpVectorCore/IElementVisitor.cs
+++ b/Source/SharpVectorCore/IElementVisitor.cs
@@ -1,0 +1,40 @@
+﻿namespace SharpVectors.Dom
+{
+    /// <summary>
+    /// Visitor that visits all renderable elements
+    /// </summary>
+    public interface IElementVisitor
+    {
+        // Shape elements
+        void Visit(Svg.ISvgCircleElement element);
+        void Visit(Svg.ISvgEllipseElement element);
+        void Visit(Svg.ISvgLineElement element);
+        void Visit(Svg.ISvgPathElement element);
+        void Visit(Svg.ISvgPolygonElement element);
+        void Visit(Svg.ISvgPolylineElement element);
+        void Visit(Svg.ISvgRectElement element);
+
+        // Graphics referencing elements
+        void Visit(Svg.ISvgImageElement element);
+        void Visit(Svg.ISvgUseElement element);
+
+        // Container elements
+        void BeginContainer(Svg.ISvgElement element);
+        void Visit(Svg.ISvgAElement element);
+        void Visit(Svg.ISvgGElement element);
+        void Visit(Svg.ISvgSvgElement element);
+        void Visit(Svg.ISvgSwitchElement element);
+        void Visit(Svg.ISvgSymbolElement element);
+        void EndContainer(Svg.ISvgElement element);
+
+        // Text content elements
+        void Visit(Svg.ISvgTextElement element);
+        void Visit(Svg.ISvgTextPathElement element);
+        void Visit(Svg.ISvgTSpanElement element);
+    }
+
+    public interface IElementVisitorTarget
+    {
+        void Accept(IElementVisitor visitor);
+    }
+}

--- a/Source/SharpVectorCore/SharpVectors.Core.csproj
+++ b/Source/SharpVectorCore/SharpVectors.Core.csproj
@@ -101,6 +101,7 @@
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IElementVisitor.cs" />
     <Compile Include="Svg\BasicTypes\SvgTextPathMethod.cs" />
     <Compile Include="Svg\BasicTypes\SvgTextPathSpacing.cs" />
     <Compile Include="Svg\DocumentStructure\ISvgColorProfileElement.cs" />

--- a/Source/SharpVectorCore/Svg/BasicTypes/ISvgAElement.cs
+++ b/Source/SharpVectorCore/Svg/BasicTypes/ISvgAElement.cs
@@ -6,8 +6,8 @@ namespace SharpVectors.Dom.Svg
 	/// </summary>
 	public interface ISvgAElement : ISvgElement, ISvgUriReference, ISvgTests,
 		ISvgLangSpace, ISvgExternalResourcesRequired, ISvgStylable, 
-        ISvgTransformable, IEventTarget
-	{
+        ISvgTransformable, IEventTarget, IElementVisitorTarget
+    {
 		ISvgAnimatedString Target{get;}
 	}
 }

--- a/Source/SharpVectorCore/Svg/DocumentStructure/ISvgGElement.cs
+++ b/Source/SharpVectorCore/Svg/DocumentStructure/ISvgGElement.cs
@@ -6,7 +6,7 @@ namespace SharpVectors.Dom.Svg
 	/// The SvgGElement interface corresponds to the 'g' element. 
 	/// </summary>
 	public interface ISvgGElement : ISvgElement, ISvgTests, ISvgLangSpace,
-		ISvgExternalResourcesRequired, ISvgStylable, ISvgTransformable, IEventTarget
-	{
+		ISvgExternalResourcesRequired, ISvgStylable, ISvgTransformable, IEventTarget, IElementVisitorTarget
+    {
 	}
 }

--- a/Source/SharpVectorCore/Svg/DocumentStructure/ISvgImageElement.cs
+++ b/Source/SharpVectorCore/Svg/DocumentStructure/ISvgImageElement.cs
@@ -4,8 +4,8 @@ namespace SharpVectors.Dom.Svg
 	/// The SvgRectElement interface corresponds to the 'image' element. 
 	/// </summary>
 	public interface ISvgImageElement : ISvgElement, ISvgTests, ISvgStylable,
-		ISvgTransformable, ISvgLangSpace, ISvgExternalResourcesRequired
-	{
+		ISvgTransformable, ISvgLangSpace, ISvgExternalResourcesRequired, IElementVisitorTarget
+    {
 		/// <summary>
 		/// Corresponds to attribute x on the given 'rect' element.
 		/// </summary>

--- a/Source/SharpVectorCore/Svg/DocumentStructure/ISvgSvgElement.cs
+++ b/Source/SharpVectorCore/Svg/DocumentStructure/ISvgSvgElement.cs
@@ -20,7 +20,7 @@ namespace SharpVectors.Dom.Svg
     /// </remarks>
     public interface ISvgSvgElement : ISvgElement, ISvgTests, ISvgLangSpace, 
         ISvgExternalResourcesRequired, ISvgStylable, ISvgLocatable, ISvgFitToViewBox, 
-        ISvgZoomAndPan, IEventTarget
+        ISvgZoomAndPan, IEventTarget, IElementVisitorTarget
     {
         /// <summary>
         /// Corresponds to attribute x on the given 'svg' element.

--- a/Source/SharpVectorCore/Svg/DocumentStructure/ISvgSwitchElement.cs
+++ b/Source/SharpVectorCore/Svg/DocumentStructure/ISvgSwitchElement.cs
@@ -6,7 +6,7 @@ namespace SharpVectors.Dom.Svg
 	/// The SvgSwitchElement interface corresponds to the 'switch' element. 
 	/// </summary>
 	public interface ISvgSwitchElement : ISvgElement, ISvgTests, ISvgLangSpace,
-        ISvgExternalResourcesRequired, ISvgStylable, ISvgTransformable, IEventTarget
-	{
+        ISvgExternalResourcesRequired, ISvgStylable, ISvgTransformable, IEventTarget, IElementVisitorTarget
+    {
 	}
 }

--- a/Source/SharpVectorCore/Svg/DocumentStructure/ISvgSymbolElement.cs
+++ b/Source/SharpVectorCore/Svg/DocumentStructure/ISvgSymbolElement.cs
@@ -3,7 +3,7 @@ using SharpVectors.Dom.Events;
 namespace SharpVectors.Dom.Svg
 {
 	public interface ISvgSymbolElement : ISvgElement, ISvgLangSpace, ISvgStylable,
-		ISvgExternalResourcesRequired, ISvgFitToViewBox, IEventTarget    
-	{
+		ISvgExternalResourcesRequired, ISvgFitToViewBox, IEventTarget, IElementVisitorTarget
+    {
 	}
 }

--- a/Source/SharpVectorCore/Svg/DocumentStructure/ISvgUseElement.cs
+++ b/Source/SharpVectorCore/Svg/DocumentStructure/ISvgUseElement.cs
@@ -6,8 +6,8 @@ namespace SharpVectors.Dom.Svg
 	/// The SvgUseElement interface corresponds to the 'use' element. 
 	/// </summary>
 	public interface ISvgUseElement : ISvgElement, ISvgUriReference, ISvgTests, ISvgStylable,
-		ISvgLangSpace, ISvgExternalResourcesRequired, ISvgTransformable, IEventTarget
-	{                                     
+		ISvgLangSpace, ISvgExternalResourcesRequired, ISvgTransformable, IEventTarget, IElementVisitorTarget
+    {                                     
 		ISvgAnimatedLength X { get; }
 		ISvgAnimatedLength Y { get; }
 		ISvgAnimatedLength Width { get; }

--- a/Source/SharpVectorCore/Svg/Paths/ISvgPathElement.cs
+++ b/Source/SharpVectorCore/Svg/Paths/ISvgPathElement.cs
@@ -6,7 +6,7 @@ namespace SharpVectors.Dom.Svg
     /// The SvgPathElement interface corresponds to the 'path' element. 
     /// </summary>
     public interface ISvgPathElement : ISvgElement, ISvgTests, ISvgLangSpace,
-        ISvgExternalResourcesRequired, ISvgStylable, ISvgTransformable, ISvgAnimatedPathData, IEventTarget
+        ISvgExternalResourcesRequired, ISvgStylable, ISvgTransformable, ISvgAnimatedPathData, IEventTarget, IElementVisitorTarget
     {
         ISvgAnimatedNumber PathLength { get; }
         double GetTotalLength();

--- a/Source/SharpVectorCore/Svg/Shapes/ISvgCircleElement.cs
+++ b/Source/SharpVectorCore/Svg/Shapes/ISvgCircleElement.cs
@@ -6,8 +6,8 @@ namespace SharpVectors.Dom.Svg
 	/// The SvgCircleElement interface corresponds to the 'circle' element. 
 	/// </summary>
 	public interface ISvgCircleElement : ISvgElement, ISvgTests, ISvgLangSpace,
-		ISvgExternalResourcesRequired, ISvgStylable, ISvgTransformable, IEventTarget
-	{
+		ISvgExternalResourcesRequired, ISvgStylable, ISvgTransformable, IEventTarget, IElementVisitorTarget
+    {
 		/// <summary>
 		/// Corresponds to attribute cx on the given 'circle' element.
 		/// </summary>

--- a/Source/SharpVectorCore/Svg/Shapes/ISvgEllipseElement.cs
+++ b/Source/SharpVectorCore/Svg/Shapes/ISvgEllipseElement.cs
@@ -6,8 +6,8 @@ namespace SharpVectors.Dom.Svg
 	/// The SvgEllipseElement interface corresponds to the 'ellipse' element. 
 	/// </summary>
 	public interface ISvgEllipseElement	: ISvgElement, ISvgTests, ISvgLangSpace,
-		ISvgExternalResourcesRequired, ISvgStylable, ISvgTransformable, IEventTarget
-	{
+		ISvgExternalResourcesRequired, ISvgStylable, ISvgTransformable, IEventTarget, IElementVisitorTarget
+    {
 		ISvgAnimatedLength Cx{get;}
 
 		ISvgAnimatedLength Cy{get;}

--- a/Source/SharpVectorCore/Svg/Shapes/ISvgLineElement.cs
+++ b/Source/SharpVectorCore/Svg/Shapes/ISvgLineElement.cs
@@ -6,8 +6,8 @@ namespace SharpVectors.Dom.Svg
 	/// The SvgLineElement interface corresponds to the 'line' element. 
 	/// </summary>
 	public interface ISvgLineElement : ISvgElement, ISvgTests, ISvgLangSpace,
-				ISvgExternalResourcesRequired, ISvgStylable, ISvgTransformable, IEventTarget
-	{
+				ISvgExternalResourcesRequired, ISvgStylable, ISvgTransformable, IEventTarget, IElementVisitorTarget
+    {
 		ISvgAnimatedLength X1{get;}
 
 		ISvgAnimatedLength Y1{get;}

--- a/Source/SharpVectorCore/Svg/Shapes/ISvgPolygonElement.cs
+++ b/Source/SharpVectorCore/Svg/Shapes/ISvgPolygonElement.cs
@@ -7,7 +7,7 @@ namespace SharpVectors.Dom.Svg
 	/// </summary>
 	public interface ISvgPolygonElement	: ISvgElement, ISvgTests, ISvgLangSpace,
 		ISvgExternalResourcesRequired, ISvgStylable, ISvgTransformable,
-		ISvgAnimatedPoints, IEventTarget
+		ISvgAnimatedPoints, IEventTarget, IElementVisitorTarget
     {
 	}
 }

--- a/Source/SharpVectorCore/Svg/Shapes/ISvgPolylineElement.cs
+++ b/Source/SharpVectorCore/Svg/Shapes/ISvgPolylineElement.cs
@@ -6,7 +6,7 @@ namespace SharpVectors.Dom.Svg
 	/// The SvgPolylineElement interface corresponds to the 'polyline' element
 	/// </summary>
 	public interface ISvgPolylineElement : ISvgElement, ISvgTests, ISvgLangSpace, ISvgExternalResourcesRequired, 
-        ISvgStylable, ISvgTransformable, ISvgAnimatedPoints, IEventTarget
+        ISvgStylable, ISvgTransformable, ISvgAnimatedPoints, IEventTarget, IElementVisitorTarget
     {
 
 	}

--- a/Source/SharpVectorCore/Svg/Shapes/ISvgRectElement.cs
+++ b/Source/SharpVectorCore/Svg/Shapes/ISvgRectElement.cs
@@ -6,8 +6,8 @@ namespace SharpVectors.Dom.Svg
 	/// The SvgRectElement interface corresponds to the 'rect' element. 
 	/// </summary>
 	public interface ISvgRectElement : ISvgElement, ISvgTests, ISvgLangSpace,
-		ISvgExternalResourcesRequired, ISvgStylable, ISvgTransformable, IEventTarget			
-	{
+		ISvgExternalResourcesRequired, ISvgStylable, ISvgTransformable, IEventTarget, IElementVisitorTarget
+    {
 		/// <summary>
 		/// Corresponds to attribute x on the given 'rect' element.
 		/// </summary>

--- a/Source/SharpVectorCore/Svg/Text/ISvgTSpanElement.cs
+++ b/Source/SharpVectorCore/Svg/Text/ISvgTSpanElement.cs
@@ -3,7 +3,7 @@ namespace SharpVectors.Dom.Svg
 	/// <summary>
 	/// The SvgTSpanElement interface corresponds to the 'tspan' element. 
 	/// </summary>
-	public interface ISvgTSpanElement : ISvgTextPositioningElement 
-	{
+	public interface ISvgTSpanElement : ISvgTextPositioningElement, IElementVisitorTarget
+    {
 	}
 }

--- a/Source/SharpVectorCore/Svg/Text/ISvgTextElement.cs
+++ b/Source/SharpVectorCore/Svg/Text/ISvgTextElement.cs
@@ -3,7 +3,7 @@ namespace SharpVectors.Dom.Svg
 	/// <summary>
 	/// The SvgTextElement interface corresponds to the 'text' element. 
 	/// </summary>
-	public interface ISvgTextElement : ISvgTransformable, ISvgTextPositioningElement
-	{
+	public interface ISvgTextElement : ISvgTransformable, ISvgTextPositioningElement, IElementVisitorTarget
+    {
 	}
 }

--- a/Source/SharpVectorCore/Svg/Text/ISvgTextPathElement.cs
+++ b/Source/SharpVectorCore/Svg/Text/ISvgTextPathElement.cs
@@ -3,8 +3,8 @@ namespace SharpVectors.Dom.Svg
 	/// <summary>
 	/// The SvgTextPathElement interface corresponds to the 'textPath' element. 
 	/// </summary>
-	public interface ISvgTextPathElement : ISvgUriReference, ISvgTextContentElement
-	{
+	public interface ISvgTextPathElement : ISvgUriReference, ISvgTextContentElement, IElementVisitorTarget
+    {
 		ISvgAnimatedLength StartOffset{get;}
 		ISvgAnimatedEnumeration Method{get;}
 		ISvgAnimatedEnumeration Spacing{get;}

--- a/Source/SharpVectorModel/DocumentStructure/SvgGElement.cs
+++ b/Source/SharpVectorModel/DocumentStructure/SvgGElement.cs
@@ -57,6 +57,28 @@ namespace SharpVectors.Dom.Svg
 
         #endregion
 
+        #region Implementation of IElementVisitorTarget
+
+        public void Accept(IElementVisitor visitor)
+        {
+            visitor.Visit(this);
+
+            if (this.HasChildNodes)
+            {
+                visitor.BeginContainer(this);
+                foreach (var item in this.ChildNodes)
+                {
+                    if (item is IElementVisitorTarget evt)
+                    {
+                        evt.Accept(visitor);
+                    }
+                }
+                visitor.EndContainer(this);
+            }
+        }
+
+        #endregion
+
         #region Implementation of ISvgTests
 
         public ISvgStringList RequiredFeatures

--- a/Source/SharpVectorModel/DocumentStructure/SvgImageElement.cs
+++ b/Source/SharpVectorModel/DocumentStructure/SvgImageElement.cs
@@ -318,6 +318,15 @@ namespace SharpVectors.Dom.Svg
 
         #endregion
 
+        #region Implementation of IElementVisitorTarget
+
+        public void Accept(IElementVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        #endregion
+
         #region Update handling
 
         public override void HandleAttributeChange(XmlAttribute attribute)

--- a/Source/SharpVectorModel/DocumentStructure/SvgSvgElement.cs
+++ b/Source/SharpVectorModel/DocumentStructure/SvgSvgElement.cs
@@ -914,6 +914,28 @@ namespace SharpVectors.Dom.Svg
 
         #endregion
 
+        #region Implementation of IElementVisitorTarget
+
+        public void Accept(IElementVisitor visitor)
+        {
+            visitor.Visit(this);
+
+            if (this.HasChildNodes)
+            {
+                visitor.BeginContainer(this);
+                foreach (var item in this.ChildNodes)
+                {
+                    if (item is IElementVisitorTarget evt)
+                    {
+                        evt.Accept(visitor);
+                    }
+                }
+                visitor.EndContainer(this);
+            }
+        }
+
+        #endregion
+
         #region ISvgExternalResourcesRequired Members
 
         public ISvgAnimatedBoolean ExternalResourcesRequired

--- a/Source/SharpVectorModel/DocumentStructure/SvgSwitchElement.cs
+++ b/Source/SharpVectorModel/DocumentStructure/SvgSwitchElement.cs
@@ -54,11 +54,33 @@ namespace SharpVectors.Dom.Svg
 			}
 		}
 
-		#endregion
+        #endregion
 
-		#region ISvgTests Members
+        #region Implementation of IElementVisitorTarget
 
-		public ISvgStringList RequiredFeatures
+        public void Accept(IElementVisitor visitor)
+        {
+            visitor.Visit(this);
+
+            if (this.HasChildNodes)
+            {
+                visitor.BeginContainer(this);
+                foreach (var item in this.ChildNodes)
+                {
+                    if (item is IElementVisitorTarget evt)
+                    {
+                        evt.Accept(visitor);
+                    }
+                }
+                visitor.EndContainer(this);
+            }
+        }
+
+        #endregion
+
+        #region ISvgTests Members
+
+        public ISvgStringList RequiredFeatures
 		{
 			get { return _svgTests.RequiredFeatures; }
 		}

--- a/Source/SharpVectorModel/DocumentStructure/SvgSymbolElement.cs
+++ b/Source/SharpVectorModel/DocumentStructure/SvgSymbolElement.cs
@@ -74,11 +74,20 @@ namespace SharpVectors.Dom.Svg
 			}
 		}
 
-		#endregion
+        #endregion
 
-		#region ISvgFitToViewBox Members
+        #region Implementation of IElementVisitorTarget
 
-		public ISvgAnimatedRect ViewBox
+        public void Accept(IElementVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        #endregion
+
+        #region ISvgFitToViewBox Members
+
+        public ISvgAnimatedRect ViewBox
 		{
 			get
 			{

--- a/Source/SharpVectorModel/DocumentStructure/SvgUseElement.cs
+++ b/Source/SharpVectorModel/DocumentStructure/SvgUseElement.cs
@@ -145,6 +145,28 @@ namespace SharpVectors.Dom.Svg
 
         #endregion
 
+        #region Implementation of IElementVisitorTarget
+
+        public void Accept(IElementVisitor visitor)
+        {
+            visitor.Visit(this);
+
+            if (this.HasChildNodes)
+            {
+                visitor.BeginContainer(this);
+                foreach (var item in this.ChildNodes)
+                {
+                    if (item is IElementVisitorTarget evt)
+                    {
+                        evt.Accept(visitor);
+                    }
+                }
+                visitor.EndContainer(this);
+            }
+        }
+
+        #endregion
+
         #region ISvgTests Members
 
         public ISvgStringList RequiredFeatures

--- a/Source/SharpVectorModel/Paths/SvgPathElement.cs
+++ b/Source/SharpVectorModel/Paths/SvgPathElement.cs
@@ -304,6 +304,15 @@ namespace SharpVectors.Dom.Svg
 
         #endregion
 
+        #region Implementation of IElementVisitorTarget
+
+        public void Accept(IElementVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        #endregion
+
         #region ISvgTests Members
 
         public ISvgStringList RequiredFeatures

--- a/Source/SharpVectorModel/Shapes/SvgCircleElement.cs
+++ b/Source/SharpVectorModel/Shapes/SvgCircleElement.cs
@@ -97,6 +97,15 @@ namespace SharpVectors.Dom.Svg
 
         #endregion
 
+        #region Implementation of IElementVisitorTarget
+
+        public void Accept(IElementVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        #endregion
+
         #region ISvgTests Members
 
         public ISvgStringList RequiredFeatures

--- a/Source/SharpVectorModel/Shapes/SvgEllipseElement.cs
+++ b/Source/SharpVectorModel/Shapes/SvgEllipseElement.cs
@@ -170,6 +170,15 @@ namespace SharpVectors.Dom.Svg
 
         #endregion
 
+        #region Implementation of IElementVisitorTarget
+
+        public void Accept(IElementVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        #endregion
+
         #region ISvgTests Members
 
         public ISvgStringList RequiredFeatures

--- a/Source/SharpVectorModel/Shapes/SvgLineElement.cs
+++ b/Source/SharpVectorModel/Shapes/SvgLineElement.cs
@@ -173,6 +173,15 @@ namespace SharpVectors.Dom.Svg
 
         #endregion
 
+        #region Implementation of IElementVisitorTarget
+
+        public void Accept(IElementVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        #endregion
+
         #region ISvgTests Members
 
         public ISvgStringList RequiredFeatures

--- a/Source/SharpVectorModel/Shapes/SvgPolygonElement.cs
+++ b/Source/SharpVectorModel/Shapes/SvgPolygonElement.cs
@@ -30,5 +30,14 @@ namespace SharpVectors.Dom.Svg
         }
 
         #endregion
+
+        #region Implementation of IElementVisitorTarget
+
+        public void Accept(IElementVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        #endregion
     }
 }

--- a/Source/SharpVectorModel/Shapes/SvgPolylineElement.cs
+++ b/Source/SharpVectorModel/Shapes/SvgPolylineElement.cs
@@ -10,5 +10,14 @@ namespace SharpVectors.Dom.Svg
 			: base(prefix, localname, ns, doc)
 		{		
 		}
-	}
+
+        #region Implementation of IElementVisitorTarget
+
+        public void Accept(IElementVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        #endregion
+    }
 }

--- a/Source/SharpVectorModel/Shapes/SvgRectElement.cs
+++ b/Source/SharpVectorModel/Shapes/SvgRectElement.cs
@@ -204,6 +204,15 @@ namespace SharpVectors.Dom.Svg
 
         #endregion
 
+        #region Implementation of IElementVisitorTarget
+
+        public void Accept(IElementVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        #endregion
+
         #region ISvgTests Members
 
         public ISvgStringList RequiredFeatures

--- a/Source/SharpVectorModel/Text/SvgTSpanElement.cs
+++ b/Source/SharpVectorModel/Text/SvgTSpanElement.cs
@@ -11,5 +11,14 @@ namespace SharpVectors.Dom.Svg
             : base(prefix, localname, ns, doc) 
 		{
 		}
+
+        #region Implementation of IElementVisitorTarget
+
+        public void Accept(IElementVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        #endregion
     }
 }

--- a/Source/SharpVectorModel/Text/SvgTextElement.cs
+++ b/Source/SharpVectorModel/Text/SvgTextElement.cs
@@ -11,5 +11,14 @@ namespace SharpVectors.Dom.Svg
             : base(prefix, localname, ns, doc) 
 		{
 		}
-	}
+
+        #region Implementation of IElementVisitorTarget
+
+        public void Accept(IElementVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        #endregion
+    }
 }

--- a/Source/SharpVectorModel/Text/SvgTextPathElement.cs
+++ b/Source/SharpVectorModel/Text/SvgTextPathElement.cs
@@ -59,6 +59,15 @@ namespace SharpVectors.Dom.Svg
 
         #endregion
 
+        #region Implementation of IElementVisitorTarget
+
+        public void Accept(IElementVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        #endregion
+
         #region ISvgUriReference Members
 
         public ISvgAnimatedString Href

--- a/Source/SharpVectorRenderingWpf/Shape/ShapeRenderingVisitor.cs
+++ b/Source/SharpVectorRenderingWpf/Shape/ShapeRenderingVisitor.cs
@@ -1,0 +1,403 @@
+﻿using SharpVectors.Dom;
+using SharpVectors.Dom.Svg;
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Xml;
+using static SharpVectors.Renderers.Wpf.Shape.WpfHelper;
+
+namespace SharpVectors.Renderers.Wpf.Shape
+{
+    public class ShapeRenderingVisitor : IElementVisitor
+    {
+        public ShapeRenderingVisitor(WpfShapeRenderer renderer)
+        {
+            this.renderer = renderer;
+        }
+
+        private WpfShapeRenderer renderer;
+        private Canvas currentCanvas;
+
+        public void BeginContainer(ISvgElement element)
+        {
+            if (element is ISvgSvgElement)
+            {
+                currentCanvas = this.renderer.Canvas;
+            }
+            else if (element is ISvgGElement)
+            {
+                var newCanvas = new Canvas();
+                currentCanvas.Children.Add(newCanvas);
+                currentCanvas = newCanvas;
+            }
+        }
+
+        public void EndContainer(ISvgElement element)
+        {
+            currentCanvas = currentCanvas?.Parent as Canvas;
+        }
+
+        public void Visit(ISvgCircleElement element)
+        {
+            double _cx = Math.Round(element.Cx.AnimVal.Value, 4);
+            double _cy = Math.Round(element.Cy.AnimVal.Value, 4);
+            double _r = Math.Round(element.R.AnimVal.Value, 4);
+
+            if (_r <= 0)
+            {
+                return;
+            }
+
+            EllipseGeometry geometry = new EllipseGeometry(new Point(_cx, _cy), _r, _r);
+            var shape = WrapGeometry(geometry, element);
+            DisplayShape(shape, element);
+        }
+
+        public void Visit(ISvgEllipseElement element)
+        {
+            double _cx = Math.Round(element.Cx.AnimVal.Value, 4);
+            double _cy = Math.Round(element.Cy.AnimVal.Value, 4);
+            double _rx = Math.Round(element.Rx.AnimVal.Value, 4);
+            double _ry = Math.Round(element.Ry.AnimVal.Value, 4);
+
+            if (_rx <= 0 || _ry <= 0)
+            {
+                return;
+            }
+
+            EllipseGeometry geometry = new EllipseGeometry(new Point(_cx, _cy),
+                _rx, _ry);
+            var shape = WrapGeometry(geometry, element);
+            DisplayShape(shape, element);
+        }
+
+        public void Visit(ISvgLineElement element)
+        {
+            double x1 = element.X1.AnimVal.Value;
+            double y1 = element.Y1.AnimVal.Value;
+            double x2 = element.X2.AnimVal.Value;
+            double y2 = element.Y2.AnimVal.Value;
+
+            var geometry = new LineGeometry(new Point(x1, y1), new Point(x2, y2));
+            var shape = WrapGeometry(geometry, element);
+            DisplayShape(shape, element);
+        }
+
+        public void Visit(ISvgPathElement element)
+        {
+            if (!(element is SvgPathElement pe) || String.IsNullOrEmpty(pe.PathScript))
+                return;
+
+            var geometry = new PathGeometry();
+
+            if (TryGetFillRule(pe, out FillRule fillRule))
+                geometry.FillRule = fillRule;
+
+            try
+            {
+                geometry.Figures = PathFigureCollection.Parse(pe.PathScript);
+            }
+            catch
+            {
+                return;
+            }
+
+            var shape = WrapGeometry(geometry, element);
+            DisplayShape(shape, element);
+        }
+
+        public void Visit(ISvgPolygonElement element)
+        {
+            ISvgPointList list = element.AnimatedPoints;
+            ulong nElems = list.NumberOfItems;
+            if (nElems == 0 || !(element is SvgPolygonElement pe))
+            {
+                return;
+            }
+
+            PointCollection points = new PointCollection((int)nElems);
+
+            for (uint i = 0; i < nElems; i++)
+            {
+                ISvgPoint point = list.GetItem(i);
+                points.Add(new Point(Math.Round(point.X, 4), Math.Round(point.Y, 4)));
+            }
+
+            PolyLineSegment polyline = new PolyLineSegment();
+            polyline.Points = points;
+
+            PathFigure polylineFigure = new PathFigure();
+            polylineFigure.StartPoint = points[0];
+            polylineFigure.IsClosed = true;
+            polylineFigure.IsFilled = true;
+
+            polylineFigure.Segments.Add(polyline);
+
+            PathGeometry geometry = new PathGeometry();
+
+            if (TryGetFillRule(pe, out FillRule fillRule))
+                geometry.FillRule = fillRule;
+
+            geometry.Figures.Add(polylineFigure);
+            var shape = WrapGeometry(geometry, element);
+            DisplayShape(shape, element);
+        }
+
+        public void Visit(ISvgPolylineElement element)
+        {
+            ISvgPointList list = element.AnimatedPoints;
+            ulong nElems = list.NumberOfItems;
+            if (nElems == 0 || !(element is SvgPolylineElement pe))
+            {
+                return;
+            }
+
+            PointCollection points = new PointCollection((int)nElems);
+
+            for (uint i = 0; i < nElems; i++)
+            {
+                ISvgPoint point = list.GetItem(i);
+                points.Add(new Point(Math.Round(point.X, 4), Math.Round(point.Y, 4)));
+            }
+            PolyLineSegment polyline = new PolyLineSegment();
+            polyline.Points = points;
+
+            PathFigure polylineFigure = new PathFigure();
+            polylineFigure.StartPoint = points[0];
+            polylineFigure.IsClosed = false;
+            polylineFigure.IsFilled = true;
+
+            polylineFigure.Segments.Add(polyline);
+
+            PathGeometry geometry = new PathGeometry();
+
+            if (TryGetFillRule(pe, out FillRule fillRule))
+                geometry.FillRule = fillRule;
+
+            geometry.Figures.Add(polylineFigure);
+            var shape = WrapGeometry(geometry, element);
+            DisplayShape(shape, element);
+        }
+
+        public void Visit(ISvgRectElement element)
+        {
+            double dx = element.X.AnimVal.Value;
+            double dy = element.Y.AnimVal.Value;
+            double width = element.Width.AnimVal.Value;
+            double height = element.Height.AnimVal.Value;
+            double rx = element.Rx.AnimVal.Value;
+            double ry = element.Ry.AnimVal.Value;
+
+            if (width <= 0 || height <= 0)
+            {
+                return;
+            }
+            if (rx <= 0 && ry > 0)
+            {
+                rx = ry;
+            }
+            else if (rx > 0 && ry <= 0)
+            {
+                ry = rx;
+            }
+
+            var geometry = new RectangleGeometry(new Rect(dx, dy, width, height), rx, ry);
+            var shape = WrapGeometry(geometry, element);
+            DisplayShape(shape, element);
+        }
+
+        public void Visit(ISvgImageElement element)
+        {
+        }
+
+        public void Visit(ISvgUseElement element)
+        {
+            SvgUseElement useElement = (SvgUseElement)element;
+            SvgDocument document = useElement.OwnerDocument;
+            XmlElement refEl = useElement.ReferencedElement;
+            if (refEl == null)
+                return;
+
+            bool isImported = false;
+            // For the external node, the documents are different, and we may not be
+            // able to insert this node, so we first import it...
+            if (useElement.OwnerDocument != refEl.OwnerDocument)
+            {
+                XmlElement importedNode =
+                    useElement.OwnerDocument.ImportNode(refEl, true) as XmlElement;
+
+                if (importedNode != null)
+                {
+                    SvgElement importedSvgElement = importedNode as SvgElement;
+                    if (importedSvgElement != null)
+                    {
+                        importedSvgElement.Imported = true;
+                        importedSvgElement.ImportNode = refEl as SvgElement;
+                        importedSvgElement.ImportDocument = refEl.OwnerDocument as SvgDocument;
+                    }
+
+                    refEl = importedNode;
+                    isImported = true;
+                }
+            }
+            XmlElement refElParent = (XmlElement)refEl.ParentNode;
+            useElement.OwnerDocument.Static = true;
+            useElement.CopyToReferencedElement(refEl);
+            if (!isImported) // if imported, we do not need to remove it...
+            {
+                refElParent.RemoveChild(refEl);
+            }
+            useElement.AppendChild(refEl);
+
+            // Now, render the use element...
+            var refElement = useElement?.FirstChild;
+            if (refElement is IElementVisitorTarget evt)
+                evt.Accept(this);
+
+            useElement.RemoveChild(refEl);
+            useElement.RestoreReferencedElement(refEl);
+            if (!isImported)
+            {
+                refElParent.AppendChild(refEl);
+            }
+            useElement.OwnerDocument.Static = false;
+        }
+
+        public void Visit(ISvgAElement element)
+        {
+        }
+
+        public void Visit(ISvgGElement element)
+        {
+        }
+
+        public void Visit(ISvgSvgElement element)
+        {
+        }
+
+        public void Visit(ISvgSwitchElement element)
+        {
+        }
+
+        public void Visit(ISvgSymbolElement element)
+        {
+        }
+
+        public void Visit(ISvgTextElement element)
+        {
+            Point position = GetCurrentTextPosition(element as SvgTextPositioningElement, new Point(0, 0));
+            Size spanSize;
+            foreach (var child in element.ChildNodes)
+            {
+                Geometry geometry;
+                System.Windows.Shapes.Path shape;
+                spanSize = new Size(0, 0);
+                switch (child)
+                {
+                    case SvgTSpanElement tspan:
+                        geometry = ConstructTextGeometry(tspan, tspan.InnerText, position, out spanSize);
+                        shape = WrapGeometry(geometry, tspan);
+                        shape.IsHitTestVisible = false;
+                        DisplayShape(shape, tspan);
+                        break;
+                    case Dom.Text simpleText:
+                        geometry = ConstructTextGeometry(element as SvgTextElement, simpleText.InnerText, position, out spanSize);
+                        shape = WrapGeometry(geometry, element);
+                        shape.IsHitTestVisible = false;
+                        DisplayShape(shape, element);
+                        break;
+                }
+                position.Offset(spanSize.Width, 0);
+            }
+        }
+
+        public void Visit(ISvgTextPathElement element)
+        {
+        }
+
+        public void Visit(ISvgTSpanElement element)
+        {
+        }
+
+        private System.Windows.Shapes.Path WrapGeometry(Geometry geometry, ISvgElement element)
+        {
+            System.Windows.Shapes.Path path = new System.Windows.Shapes.Path();
+            if (TryGetTransform(element as ISvgTransformable, out Transform transform))
+                geometry.Transform = transform;
+            path.Data = geometry;
+            return path;
+        }
+
+        private void DisplayShape(System.Windows.Shapes.Path shape, ISvgElement element, bool applyStyle = true)
+        {
+            if (currentCanvas == null)
+                return;
+
+            if (applyStyle)
+            {
+                var style = CreateStyle(shape, element as SvgStyleableElement);
+                if (style != null)
+                    shape.Style = style;
+            }
+            Geometry geom = shape.Data;
+            if (geom != null && geom.CanFreeze && !geom.IsFrozen)
+                geom.Freeze();
+            currentCanvas.Children.Add(shape);
+        }
+
+        private Style CreateStyle(System.Windows.Shapes.Path shape, SvgStyleableElement element)
+        {
+            if (element == null)
+                return null;
+
+            Style style = new Style();
+            style.BasedOn = this.renderer.ItemStyle;
+
+            style.Setters.Add(new Setter(System.Windows.Shapes.Shape.SnapsToDevicePixelsProperty, true));
+
+            Rect shapeBounds = Rect.Empty;
+            Matrix shapeTransform = Matrix.Identity;
+            if (shape.Data != null)
+            {
+                if (shape.Data.Transform?.Value.IsIdentity == true)
+                {
+                    shapeBounds = shape.Data.Bounds;
+                }
+                else
+                {
+                    var transform = shape.Data.Transform;
+                    shape.Data.Transform = null;
+                    shapeBounds = shape.Data.Bounds;
+                    shape.Data.Transform = transform;
+                    shapeTransform = transform.Value;
+                }
+            }
+
+            // Stroke
+            if (TryGetBrush(element, "stroke", shapeBounds, shapeTransform, out Brush stroke))
+                style.Setters.Add(new Setter(System.Windows.Shapes.Shape.StrokeProperty, stroke));
+            if (TryGetStrokeWidth(element, out double strokeWidth))
+                style.Setters.Add(new Setter(System.Windows.Shapes.Shape.StrokeThicknessProperty, strokeWidth));
+            if (TryGetMiterLimit(element, strokeWidth, out double miterLimit))
+                style.Setters.Add(new Setter(System.Windows.Shapes.Shape.StrokeMiterLimitProperty, miterLimit));
+            if (TryGetLineJoin(element, out PenLineJoin lineJoin))
+                style.Setters.Add(new Setter(System.Windows.Shapes.Shape.StrokeLineJoinProperty, lineJoin));
+            if (TryGetLineCap(element, out PenLineCap lineCap))
+            {
+                style.Setters.Add(new Setter(System.Windows.Shapes.Shape.StrokeStartLineCapProperty, lineCap));
+                style.Setters.Add(new Setter(System.Windows.Shapes.Shape.StrokeEndLineCapProperty, lineCap));
+            }
+            if (TryGetDashArray(element, strokeWidth, out DoubleCollection dashArray))
+                style.Setters.Add(new Setter(System.Windows.Shapes.Shape.StrokeDashArrayProperty, dashArray));
+            if (TryGetDashOffset(element, strokeWidth, out double dashOffset))
+                style.Setters.Add(new Setter(System.Windows.Shapes.Shape.StrokeDashOffsetProperty, dashOffset));
+
+            // Fill
+            if (TryGetBrush(element, "fill", shapeBounds, shapeTransform, out Brush fill))
+                style.Setters.Add(new Setter(System.Windows.Shapes.Shape.FillProperty, fill));
+
+            return style;
+        }
+    }
+}

--- a/Source/SharpVectorRenderingWpf/Shape/UI/SvgShapeViewer.cs
+++ b/Source/SharpVectorRenderingWpf/Shape/UI/SvgShapeViewer.cs
@@ -1,0 +1,118 @@
+﻿using SharpVectors.Renderers.Utils;
+using System;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace SharpVectors.Renderers.Wpf.Shape
+{
+    /// <summary>
+    /// Component that visualizes svg document contents.
+    /// </summary>
+    public class SvgShapeViewer : Canvas
+    {
+        public static readonly DependencyProperty SourceProperty = DependencyProperty.Register("Source",
+            typeof(string), typeof(SvgShapeViewer), new PropertyMetadata(OnSourcePropertyChanged));
+
+        public static readonly DependencyProperty ItemStyleProperty = DependencyProperty.Register("ItemStyle",
+            typeof(Style), typeof(SvgShapeViewer), new PropertyMetadata(OnItemStylePropertyChanged));
+
+        public SvgShapeViewer()
+        {
+            _wpfRenderer = new WpfShapeRenderer();
+            _wpfRenderer.Canvas = this;
+            _wpfWindow = new WpfSvgWindow(640, 480, _wpfRenderer);
+            ClipToBounds = true;
+            Bounds = Rect.Empty;
+        }
+
+        private WpfSvgWindow _wpfWindow;
+        private WpfShapeRenderer _wpfRenderer;
+
+        /// <summary>
+        /// Gets or sets svg document source.
+        /// </summary>
+        public string Source
+        {
+            get => (string)GetValue(SourceProperty);
+            set => SetValue(SourceProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets an item style that will be applied to all svg elements.
+        /// </summary>
+        /// <remarks>
+        /// This style will be used as a BasedOn style for all shapes created from
+        /// svg elements.
+        /// </remarks>
+        public Style ItemStyle
+        {
+            get => (Style)GetValue(ItemStyleProperty);
+            set => SetValue(ItemStyleProperty, value);
+        }
+
+        /// <summary>
+        /// Gets the bounding box of the svg document.
+        /// </summary>
+        public Rect Bounds { get; private set; }
+
+        /// <summary>
+        /// Unloads loaded svg.
+        /// </summary>
+        public void UnloadDiagrams()
+        {
+            this.Children.Clear();
+            this.Bounds = Rect.Empty;
+        }
+
+        protected override Size MeasureOverride(Size constraint)
+        {
+            var baseSize = base.MeasureOverride(constraint);
+            if (_wpfWindow.Document?.RootElement == null)
+            {
+                return baseSize;
+            }
+
+            var rect = this.Bounds;
+            return new Size(rect.Width, rect.Height);
+        }
+
+        private static void OnSourcePropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+        {
+            (sender as SvgShapeViewer).Load(e.NewValue as string);
+        }
+
+        private static void OnItemStylePropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+        {
+            (sender as SvgShapeViewer)._wpfRenderer.ItemStyle = e.NewValue as Style;
+        }
+
+        private void Load(string uri)
+        {
+            UnloadDiagrams();
+
+            if (string.IsNullOrEmpty(uri))
+                return;
+
+            try
+            {
+                _wpfWindow.LoadDocument(uri);
+                _wpfRenderer.Render(_wpfWindow.Document);
+                this.Bounds = CalculateBounds(_wpfWindow);
+            }
+            catch (Exception e)
+            {
+                System.Diagnostics.Debug.WriteLine(e.ToString());
+                UnloadDiagrams();
+            }
+        }
+
+        private static Rect CalculateBounds(WpfSvgWindow window)
+        {
+            if (window.Document?.RootElement == null)
+                return Rect.Empty;
+
+            var rect = window.Document.RootElement.GetBBox();
+            return new Rect(rect.X, rect.Y, rect.Width, rect.Height);
+        }
+    }
+}

--- a/Source/SharpVectorRenderingWpf/Shape/WpfHelper.cs
+++ b/Source/SharpVectorRenderingWpf/Shape/WpfHelper.cs
@@ -1,0 +1,800 @@
+﻿using SharpVectors.Dom.Css;
+using SharpVectors.Dom.Svg;
+using System;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Media;
+
+namespace SharpVectors.Renderers.Wpf.Shape
+{
+    public static class WpfHelper
+    {
+        private static readonly Regex _decimalNumber = new Regex(@"^\d");
+        private static readonly string GenericSerifFontFamily = "Times New Roman";
+        private static readonly string GenericSansSerifFontFamily = "Tahoma";
+        private static readonly string GenericMonospaceFontFamily = "MS Gothic";
+        private static readonly string DefaultFontFamily = "Arial Unicode MS";
+
+        public static bool TryGetStrokeWidth(SvgStyleableElement element, out double strokeWidth)
+        {
+            string propValue = element.GetPropertyValue("stroke-width");
+            if (string.IsNullOrEmpty(propValue))
+            {
+                strokeWidth = 1d;
+                return false;
+            }
+
+            SvgLength strokeWidthLength = new SvgLength(element, "stroke-width", SvgLengthDirection.Viewport, propValue);
+            strokeWidth = strokeWidthLength.Value;
+            return true;
+        }
+
+        public static bool TryGetMiterLimit(SvgStyleableElement element, double strokeWidth, out double miterLimit)
+        {
+            string miterLimitAttr = element.GetAttribute("stroke-miterlimit");
+            if (String.IsNullOrEmpty(miterLimitAttr))
+            {
+                string strokeLinecap = element.GetAttribute("stroke-linecap");
+                if (String.Equals(strokeLinecap, "round", StringComparison.OrdinalIgnoreCase))
+                {
+                    miterLimit = 1.0d;
+                    return true;
+                }
+                miterLimit = -1.0d;
+                return false;
+            }
+
+            string miterLimitStr = element.GetPropertyValue("stroke-miterlimit");
+            if (String.IsNullOrEmpty(miterLimitStr) || strokeWidth <= 0)
+            {
+                miterLimit = -1.0d;
+                return false;
+            }
+
+            miterLimit = SvgNumber.ParseNumber(miterLimitStr);
+            if (miterLimit < 1)
+                return false;
+
+            double ratioLimit = miterLimit / strokeWidth;
+            if (ratioLimit < 1.8d)
+            {
+                miterLimit = 1.0d;
+            }
+            return true;
+        }
+
+        public static bool TryGetFillRule(SvgStyleableElement element, out FillRule fillRule)
+        {
+            string fillRuleStr = element.GetPropertyValue("fill-rule");
+            string clipRule = element.GetAttribute("clip-rule");
+            if (!String.IsNullOrEmpty(clipRule) &&
+                String.Equals(clipRule, "evenodd") || String.Equals(clipRule, "nonzero"))
+            {
+                fillRuleStr = clipRule;
+            }
+            if (StringComparer.InvariantCultureIgnoreCase.Equals(fillRuleStr, "evenodd"))
+            {
+                fillRule = FillRule.EvenOdd;
+                return true;
+            }
+            else if (StringComparer.InvariantCultureIgnoreCase.Equals(fillRuleStr, "nonzero"))
+            {
+                fillRule = FillRule.Nonzero;
+                return true;
+            }
+            fillRule = FillRule.EvenOdd;
+            return false;
+        }
+
+        public static bool TryGetSpreadMethod(SvgSpreadMethod sm, out GradientSpreadMethod spreadMethod)
+        {
+            if (sm == SvgSpreadMethod.None)
+            {
+                spreadMethod = GradientSpreadMethod.Pad;
+                return false;
+            }
+
+            spreadMethod = (GradientSpreadMethod)sm;
+            return true;
+        }
+
+        public static Matrix ToWpfMatrix(ISvgMatrix svgMatrix)
+        {
+            return new Matrix(svgMatrix.A, svgMatrix.B, svgMatrix.C,
+                svgMatrix.D, svgMatrix.E, svgMatrix.F);
+        }
+
+        public static bool TryGetLineJoin(SvgStyleableElement element, out PenLineJoin lineJoin)
+        {
+            switch (element.GetPropertyValue("stroke-linejoin"))
+            {
+                case "round":
+                    lineJoin = PenLineJoin.Round;
+                    return true;
+                case "bevel":
+                    lineJoin = PenLineJoin.Bevel;
+                    return true;
+                case "miter":
+                    lineJoin = PenLineJoin.Miter;
+                    return true;
+            }
+            lineJoin = PenLineJoin.Bevel;
+            return false;
+        }
+
+        public static bool TryGetLineCap(SvgStyleableElement element, out PenLineCap lineCap)
+        {
+            switch (element.GetPropertyValue("stroke-linecap"))
+            {
+                case "round":
+                    lineCap = PenLineCap.Round;
+                    return true;
+                case "square":
+                    lineCap = PenLineCap.Square;
+                    return true;
+                case "butt":
+                    lineCap = PenLineCap.Flat;
+                    return true;
+                case "triangle":
+                    lineCap = PenLineCap.Triangle;
+                    return true;
+            }
+            lineCap = PenLineCap.Flat;
+            return false;
+        }
+
+        public static bool TryGetDashArray(SvgStyleableElement element, double strokeWidth, out DoubleCollection dashArray)
+        {
+            dashArray = null;
+            string dashArrayText = element.GetPropertyValue("stroke-dasharray");
+            if (String.IsNullOrEmpty(dashArrayText))
+            {
+                return false;
+            }
+
+            if (dashArrayText == "none")
+            {
+                return false;
+            }
+            else
+            {
+                SvgNumberList list = new SvgNumberList(dashArrayText);
+
+                uint len = list.NumberOfItems;
+                dashArray = new DoubleCollection((int)len);
+
+                for (uint i = 0; i < len; i++)
+                {
+                    //divide by strokeWidth to take care of the difference between Svg and WPF
+                    dashArray.Add(list.GetItem(i).Value / strokeWidth);
+                }
+
+                return true;
+            }
+        }
+
+        public static bool TryGetDashOffset(SvgStyleableElement element, double strokeWidth, out double offset)
+        {
+            string dashOffset = element.GetPropertyValue("stroke-dashoffset");
+            if (dashOffset.Length > 0)
+            {
+                //divide by strokeWidth to take care of the difference between Svg and GDI+
+                SvgLength dashOffsetLength = new SvgLength(element, "stroke-dashoffset",
+                    SvgLengthDirection.Viewport, dashOffset);
+                offset = dashOffsetLength.Value;
+                return true;
+            }
+            offset = 0;
+            return false;
+        }
+
+        public static bool TryGetBrush(SvgStyleableElement element, string property, Rect bounds, Matrix transform, out Brush brush)
+        {
+            SvgPaint paint = new SvgPaint(element.GetComputedStyle("").GetPropertyValue(property));
+            SvgPaint svgBrush;
+            if (paint.PaintType == SvgPaintType.None)
+            {
+                brush = null;
+                return false;
+            }
+            else if (paint.PaintType == SvgPaintType.CurrentColor)
+            {
+                svgBrush = new SvgPaint(element.GetComputedStyle("").GetPropertyValue("color"));
+            }
+            else
+            {
+                svgBrush = paint;
+            }
+
+            SvgPaintType paintType = svgBrush.PaintType;
+            if (paintType == SvgPaintType.Uri || paintType == SvgPaintType.UriCurrentColor ||
+                paintType == SvgPaintType.UriNone || paintType == SvgPaintType.UriRgbColor ||
+                paintType == SvgPaintType.UriRgbColorIccColor)
+            {
+                SvgStyleableElement fillNode = null;
+                string absoluteUri = element.ResolveUri(svgBrush.Uri);
+
+                if (element.Imported && element.ImportDocument != null &&
+                    element.ImportNode != null)
+                {
+                    // We need to determine whether the provided URI refers to element in the
+                    // original document or in the current document...
+                    SvgStyleableElement styleElm = element.ImportNode as SvgStyleableElement;
+                    if (styleElm != null)
+                    {
+                        string propertyValue = styleElm.GetComputedStyle("").GetPropertyValue(property);
+
+                        if (!String.IsNullOrEmpty(propertyValue))
+                        {
+                            SvgPaint importFill = new SvgPaint(styleElm.GetComputedStyle("").GetPropertyValue(property));
+                            if (String.Equals(svgBrush.Uri, importFill.Uri, StringComparison.OrdinalIgnoreCase))
+                            {
+                                fillNode = element.ImportDocument.GetNodeByUri(absoluteUri) as SvgStyleableElement;
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    fillNode = element.OwnerDocument.GetNodeByUri(absoluteUri) as SvgStyleableElement;
+                }
+
+                if (fillNode != null)
+                {
+                    switch (fillNode)
+                    {
+                        case SvgLinearGradientElement linearGradient:
+                            brush = ConstructBrush(linearGradient, bounds, transform);
+                            return true;
+                        case SvgRadialGradientElement radialGradient:
+                            brush = ConstructBrush(radialGradient, bounds, transform);
+                            return true;
+                        case SvgPatternElement pattern:
+                            brush = ConstructBrush(pattern, bounds, transform);
+                            return true;
+                    }
+                }
+            }
+
+            if (svgBrush == null || svgBrush.RgbColor == null ||
+                !TryConvertColor(svgBrush.RgbColor, out Color solidColor))
+            {
+                brush = null;
+                return false;
+            }
+
+            brush = new SolidColorBrush(solidColor);
+            brush.Opacity = GetOpacity(element, property);
+            if (brush.CanFreeze)
+                brush.Freeze();
+            return true;
+        }
+
+        public static LinearGradientBrush ConstructBrush(SvgLinearGradientElement gradient, Rect bounds, Matrix transform)
+        {
+            if (gradient.Stops.Count == 0)
+                return null;
+
+            double x1 = gradient.X1.AnimVal.Value;
+            double x2 = gradient.X2.AnimVal.Value;
+            double y1 = gradient.Y1.AnimVal.Value;
+            double y2 = gradient.Y2.AnimVal.Value;
+
+            GradientStopCollection gradientStops = ToGradientStops(gradient.Stops);
+
+            LinearGradientBrush brush = new LinearGradientBrush(gradientStops,
+                new Point(x1, y1), new Point(x2, y2));
+
+            SvgSpreadMethod spreadMethod = SvgSpreadMethod.Pad;
+            if (gradient.SpreadMethod != null)
+            {
+                spreadMethod = (SvgSpreadMethod)gradient.SpreadMethod.AnimVal;
+                if (TryGetSpreadMethod(spreadMethod, out GradientSpreadMethod sm))
+                {
+                    brush.SpreadMethod = sm;
+                }
+            }
+
+            SvgUnitType mappingMode = SvgUnitType.ObjectBoundingBox;
+            if (gradient.GradientUnits != null)
+            {
+                mappingMode = (SvgUnitType)gradient.GradientUnits.AnimVal;
+                if (mappingMode == SvgUnitType.ObjectBoundingBox)
+                {
+                    brush.MappingMode = BrushMappingMode.RelativeToBoundingBox;
+                }
+                else if (mappingMode == SvgUnitType.UserSpaceOnUse)
+                {
+                    brush.MappingMode = BrushMappingMode.Absolute;
+                    brush.StartPoint.Offset(bounds.X, bounds.Y);
+                    brush.EndPoint.Offset(bounds.X, bounds.Y);
+                }
+            }
+
+            Matrix brushTransform = ToWpfMatrix(((SvgTransformList)gradient.GradientTransform.AnimVal).TotalMatrix);
+            if (mappingMode == SvgUnitType.UserSpaceOnUse)
+            {
+                brushTransform *= transform;
+            }
+            if (!brushTransform.IsIdentity)
+            {
+                brush.Transform = new MatrixTransform(brushTransform);
+            }
+
+            string colorInterpolation = gradient.GetPropertyValue("color-interpolation");
+            if (!String.IsNullOrEmpty(colorInterpolation))
+            {
+                if (colorInterpolation == "linearRGB")
+                {
+                    brush.ColorInterpolationMode = ColorInterpolationMode.ScRgbLinearInterpolation;
+                }
+                else
+                {
+                    brush.ColorInterpolationMode = ColorInterpolationMode.SRgbLinearInterpolation;
+                }
+            }
+
+            return brush;
+        }
+
+        public static RadialGradientBrush ConstructBrush(SvgRadialGradientElement gradient, Rect bounds, Matrix transform)
+        {
+            if (gradient.Stops.Count == 0)
+                return null;
+
+            double centerX = gradient.Cx.AnimVal.Value;
+            double centerY = gradient.Cy.AnimVal.Value;
+            double focusX = gradient.Fx.AnimVal.Value;
+            double focusY = gradient.Fy.AnimVal.Value;
+            double radius = gradient.R.AnimVal.Value;
+
+            GradientStopCollection gradientStops = ToGradientStops(gradient.Stops);
+
+            RadialGradientBrush brush = new RadialGradientBrush(gradientStops);
+
+            brush.RadiusX = radius;
+            brush.RadiusY = radius;
+            brush.Center = new Point(centerX, centerY);
+            brush.GradientOrigin = new Point(focusX, focusY);
+
+            if (gradient.SpreadMethod != null)
+            {
+                SvgSpreadMethod spreadMethod = (SvgSpreadMethod)gradient.SpreadMethod.AnimVal;
+                if (TryGetSpreadMethod(spreadMethod, out GradientSpreadMethod sm))
+                {
+                    brush.SpreadMethod = sm;
+                }
+            }
+
+            SvgUnitType mappingMode = SvgUnitType.ObjectBoundingBox;
+            if (gradient.GradientUnits != null)
+            {
+                mappingMode = (SvgUnitType)gradient.GradientUnits.AnimVal;
+                if (mappingMode == SvgUnitType.ObjectBoundingBox)
+                {
+                    brush.MappingMode = BrushMappingMode.RelativeToBoundingBox;
+                }
+                else if (mappingMode == SvgUnitType.UserSpaceOnUse)
+                {
+                    brush.MappingMode = BrushMappingMode.Absolute;
+                    brush.Center.Offset(bounds.X, bounds.Y);
+                    brush.GradientOrigin.Offset(bounds.X, bounds.Y);
+                }
+            }
+
+            Matrix brushTransform = ToWpfMatrix(((SvgTransformList)gradient.GradientTransform.AnimVal).TotalMatrix);
+            if (mappingMode == SvgUnitType.UserSpaceOnUse)
+            {
+                brushTransform *= transform;
+            }
+            if (!brushTransform.IsIdentity)
+            {
+                brush.Transform = new MatrixTransform(brushTransform);
+            }
+
+            string colorInterpolation = gradient.GetPropertyValue("color-interpolation");
+            if (!String.IsNullOrEmpty(colorInterpolation))
+            {
+                if (colorInterpolation == "linearRGB")
+                {
+                    brush.ColorInterpolationMode = ColorInterpolationMode.SRgbLinearInterpolation;
+                }
+                else
+                {
+                    brush.ColorInterpolationMode = ColorInterpolationMode.ScRgbLinearInterpolation;
+                }
+            }
+
+            return brush;
+        }
+
+        public static ImageBrush ConstructBrush(SvgPatternElement linearGradient, Rect bounds, Matrix transform)
+        {
+            return null;
+        }
+
+        public static GradientStopCollection ToGradientStops(System.Xml.XmlNodeList stops)
+        {
+            int itemCount = stops.Count;
+            GradientStopCollection gradientStops = new GradientStopCollection(itemCount);
+
+            double lastOffset = 0;
+            for (int i = 0; i < itemCount; i++)
+            {
+                SvgStopElement stop = (SvgStopElement)stops.Item(i);
+                string prop = stop.GetAttribute("stop-color");
+                string style = stop.GetAttribute("style");
+                Color color = Colors.Transparent; // no auto-inherited...
+                if (!String.IsNullOrEmpty(prop) || !String.IsNullOrEmpty(style))
+                {
+                    SvgColor svgColor = new SvgColor(stop.GetComputedStyle("").GetPropertyValue("stop-color"));
+                    if (svgColor.ColorType == SvgColorType.CurrentColor)
+                    {
+                        string sCurColor = stop.GetComputedStyle("").GetPropertyValue("color");
+                        svgColor = new SvgColor(sCurColor);
+                    }
+                    TryConvertColor(svgColor.RgbColor, out color);
+                }
+                else
+                {
+                    color = Colors.Black; // the default color...
+                }
+
+                double alpha = 255;
+                string opacity;
+
+                opacity = stop.GetAttribute("stop-opacity"); // no auto-inherit
+                if (opacity == "inherit") // if explicitly defined...
+                {
+                    opacity = stop.GetPropertyValue("stop-opacity");
+                }
+                if (!String.IsNullOrEmpty(opacity))
+                    alpha *= SvgNumber.ParseNumber(opacity);
+
+                alpha = Math.Min(alpha, 255);
+                alpha = Math.Max(alpha, 0);
+
+                color = Color.FromArgb((byte)Convert.ToInt32(alpha),
+                    color.R, color.G, color.B);
+
+                double offset = stop.Offset.AnimVal;
+
+                offset /= 100;
+                offset = Math.Max(lastOffset, offset);
+
+                gradientStops.Add(new GradientStop(color, offset));
+                lastOffset = offset;
+            }
+
+            return gradientStops;
+        }
+
+        public static bool TryConvertColor(ICssColor color, out Color wpfColor)
+        {
+            wpfColor = Colors.Black;
+            if (color == null)
+            {
+                return false;
+            }
+
+            double dRed = color.Red.GetFloatValue(CssPrimitiveType.Number);
+            double dGreen = color.Green.GetFloatValue(CssPrimitiveType.Number);
+            double dBlue = color.Blue.GetFloatValue(CssPrimitiveType.Number);
+
+            if (Double.IsNaN(dRed) || Double.IsInfinity(dRed) ||
+                Double.IsNaN(dGreen) || Double.IsInfinity(dGreen) ||
+                Double.IsNaN(dBlue) || Double.IsInfinity(dBlue))
+                return false;
+
+            wpfColor = Color.FromRgb(Convert.ToByte(dRed), Convert.ToByte(dGreen), Convert.ToByte(dBlue));
+            return true;
+        }
+
+        public static double GetOpacity(SvgStyleableElement element, string fillOrStroke)
+        {
+            double opacityValue = 1;
+
+            string opacity = element.GetPropertyValue(fillOrStroke + "-opacity");
+            if (opacity != null && opacity.Length > 0)
+            {
+                opacityValue *= SvgNumber.ParseNumber(opacity);
+            }
+
+            opacity = element.GetPropertyValue("opacity");
+            if (opacity != null && opacity.Length > 0)
+            {
+                opacityValue *= SvgNumber.ParseNumber(opacity);
+            }
+
+            opacityValue = Math.Min(opacityValue, 1);
+            opacityValue = Math.Max(opacityValue, 0);
+
+            return opacityValue;
+        }
+
+        public static bool TryGetTransform(ISvgTransformable element, out Transform transform)
+        {
+            transform = null;
+
+            if (element == null)
+                return false;
+
+            ISvgTransformList svgTList = (ISvgTransformList)element.Transform.AnimVal;
+            ISvgMatrix svgMatrix = ((SvgTransformList)element.Transform.AnimVal).TotalMatrix;
+            ISvgElement nVE = element.NearestViewportElement;
+            if (nVE != null)
+            {
+                SvgTransformableElement par = (element as SvgElement).ParentNode as SvgTransformableElement;
+                while (par != null && par != nVE)
+                {
+                    svgTList = par.Transform.AnimVal;
+                    svgMatrix = svgTList.Consolidate().Matrix.Multiply(svgMatrix);
+                    par = par.ParentNode as SvgTransformableElement;
+                }
+            }
+
+            if (svgMatrix.IsIdentity)
+            {
+                transform = Transform.Identity;
+                return false;
+            }
+
+            transform = new MatrixTransform(ToWpfMatrix(svgMatrix));
+            return true;
+        }
+
+        public static Geometry ConstructTextGeometry(SvgTextContentElement textContentElement, string text, Point position, out Size textDimensions)
+        {
+            Typeface typeface = new Typeface(
+                GetTextFontFamily(textContentElement),
+                GetTextFontStyle(textContentElement),
+                GetTextFontWeight(textContentElement),
+                GetTextFontStretch(textContentElement));
+
+            FormattedText formattedText = new FormattedText(text,
+                System.Globalization.CultureInfo.CurrentUICulture,
+                GetTextDirection(textContentElement),
+                typeface,
+                GetComputedFontSize(textContentElement),
+                Brushes.Black)
+            {
+                LineHeight = GetComputedLineHeight(textContentElement)
+            };
+
+            if (textContentElement is SvgTextPositioningElement tpe)
+            {
+                position = GetCurrentTextPosition(tpe, position);
+            }
+            position.Y -= formattedText.Height;
+
+            textDimensions = new Size(formattedText.Width, formattedText.Height);
+            return formattedText.BuildGeometry(position);
+        }
+
+        public static Point GetCurrentTextPosition(SvgTextPositioningElement posElement, Point p)
+        {
+            if (posElement.X.AnimVal.NumberOfItems > 0)
+            {
+                p.X = (float)posElement.X.AnimVal.GetItem(0).Value;
+            }
+            if (posElement.Y.AnimVal.NumberOfItems > 0)
+            {
+                p.Y = (float)posElement.Y.AnimVal.GetItem(0).Value;
+            }
+            if (posElement.Dx.AnimVal.NumberOfItems > 0)
+            {
+                p.X += (float)posElement.Dx.AnimVal.GetItem(0).Value;
+            }
+            if (posElement.Dy.AnimVal.NumberOfItems > 0)
+            {
+                p.Y += (float)posElement.Dy.AnimVal.GetItem(0).Value;
+            }
+            return p;
+        }
+
+        private static FlowDirection GetTextDirection(SvgTextContentElement element)
+        {
+            string dir = element.GetPropertyValue("direction");
+            bool isRightToLeft = (dir == "rtl");
+            return isRightToLeft ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
+        }
+
+        private static double GetComputedFontSize(SvgTextContentElement element)
+        {
+            string str = element.GetPropertyValue("font-size");
+            double fontSize = 12;
+            if (str.EndsWith("%"))
+            {
+                // percentage of inherited value
+            }
+            else if (_decimalNumber.IsMatch(str))
+            {
+                // svg length
+                fontSize = new SvgLength(element, "font-size",
+                    SvgLengthDirection.Viewport, str, "10px").Value;
+            }
+            else if (str == "larger")
+            {
+            }
+            else if (str == "smaller")
+            {
+
+            }
+            else
+            {
+                // check for absolute value
+            }
+
+            return fontSize;
+        }
+
+        private static double GetComputedLineHeight(SvgTextContentElement element)
+        {
+            string str = element.GetPropertyValue("line-height");
+            double lineHeight = 13;
+            if (str.EndsWith("%"))
+            {
+                // percentage of inherited value
+            }
+            else if (_decimalNumber.IsMatch(str))
+            {
+                // svg length
+                lineHeight = new SvgLength(element, "line-height",
+                    SvgLengthDirection.Viewport, str, "13px").Value;
+            }
+
+            return lineHeight;
+        }
+
+        private static FontFamily GetTextFontFamily(SvgTextContentElement element)
+        {
+            string fontFamily = element.GetPropertyValue("font-family");
+            string[] fontNames = fontNames = fontFamily.Split(new char[1] { ',' });
+
+            foreach (string fn in fontNames)
+            {
+                try
+                {
+                    string fontName = fn.Trim(new char[] { ' ', '\'', '"' });
+
+                    if (String.Equals(fontName, "serif", StringComparison.OrdinalIgnoreCase))
+                    {
+                        fontName = GenericSerifFontFamily;
+                    }
+                    else if (String.Equals(fontName, "sans-serif", StringComparison.OrdinalIgnoreCase))
+                    {
+                        fontName = GenericSansSerifFontFamily;
+                    }
+                    else if (String.Equals(fontName, "monospace", StringComparison.OrdinalIgnoreCase))
+                    {
+                        fontName = GenericMonospaceFontFamily;
+                    }
+
+                    if (!string.IsNullOrEmpty(fontName))
+                        return new FontFamily(fontName);
+                }
+                catch
+                {
+                }
+            }
+
+            // no known font-family was found => default to Arial
+            return new FontFamily(DefaultFontFamily);
+        }
+
+        private static FontStyle GetTextFontStyle(SvgTextContentElement element)
+        {
+            string fontStyle = element.GetPropertyValue("font-style");
+            if (String.IsNullOrEmpty(fontStyle))
+            {
+                return FontStyles.Normal;
+            }
+
+            if (fontStyle == "normal")
+            {
+                return FontStyles.Normal;
+            }
+            if (fontStyle == "italic")
+            {
+                return FontStyles.Italic;
+            }
+            if (fontStyle == "oblique")
+            {
+                return FontStyles.Oblique;
+            }
+
+            return FontStyles.Normal;
+        }
+
+        private static FontStretch GetTextFontStretch(SvgTextContentElement element)
+        {
+            string fontStretch = element.GetPropertyValue("font-stretch");
+            if (String.IsNullOrEmpty(fontStretch))
+            {
+                return FontStretches.Normal;
+            }
+
+            switch (fontStretch)
+            {
+                case "normal":
+                    return FontStretches.Normal;
+                case "ultra-condensed":
+                    return FontStretches.UltraCondensed;
+                case "extra-condensed":
+                    return FontStretches.ExtraCondensed;
+                case "condensed":
+                    return FontStretches.Condensed;
+                case "semi-condensed":
+                    return FontStretches.SemiCondensed;
+                case "semi-expanded":
+                    return FontStretches.SemiExpanded;
+                case "expanded":
+                    return FontStretches.Expanded;
+                case "extra-expanded":
+                    return FontStretches.ExtraExpanded;
+                case "ultra-expanded":
+                    return FontStretches.UltraExpanded;
+            }
+
+            return FontStretches.Normal;
+        }
+
+        private static TextDecorationCollection GetTextDecoration(SvgTextContentElement element)
+        {
+            string textDeco = element.GetPropertyValue("text-decoration");
+            if (textDeco == "line-through")
+            {
+                return TextDecorations.Strikethrough;
+            }
+            if (textDeco == "underline")
+            {
+                return TextDecorations.Underline;
+            }
+            if (textDeco == "overline")
+            {
+                return TextDecorations.OverLine;
+            }
+
+            return null;
+        }
+
+        private static FontWeight GetTextFontWeight(SvgTextContentElement element)
+        {
+            string fontWeight = element.GetPropertyValue("font-weight");
+            if (String.IsNullOrEmpty(fontWeight))
+            {
+                return FontWeights.Normal;
+            }
+
+            switch (fontWeight)
+            {
+                case "normal":
+                    return FontWeights.Normal;
+                case "bold":
+                    return FontWeights.Bold;
+                case "100":
+                    return FontWeights.Thin;
+                case "200":
+                    return FontWeights.ExtraLight;
+                case "300":
+                    return FontWeights.Light;
+                case "400":
+                    return FontWeights.Normal;
+                case "500":
+                    return FontWeights.Medium;
+                case "600":
+                    return FontWeights.SemiBold;
+                case "700":
+                    return FontWeights.Bold;
+                case "800":
+                    return FontWeights.ExtraBold;
+                case "900":
+                    return FontWeights.Black;
+                case "950":
+                    return FontWeights.UltraBlack;
+            }
+
+            return FontWeights.Normal;
+        }
+    }
+}

--- a/Source/SharpVectorRenderingWpf/Shape/WpfShapeRenderer.cs
+++ b/Source/SharpVectorRenderingWpf/Shape/WpfShapeRenderer.cs
@@ -1,0 +1,45 @@
+﻿using SharpVectors.Dom.Svg;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace SharpVectors.Renderers.Wpf.Shape
+{
+    public class WpfShapeRenderer : ISvgRenderer
+    {
+        public Style ItemStyle { get; set; }
+        public ISvgWindow Window { get; set; }
+        public SvgRectF InvalidRect { get; set; }
+        public RenderEvent OnRender { get; set; }
+
+        public Canvas Canvas { get; set; }
+
+        public ISvgRect GetRenderedBounds(ISvgElement element, float margin)
+        {
+            return (element is ISvgSvgElement svgElement) ? svgElement.ViewBox.AnimVal : SvgRect.Empty;
+        }
+
+        public void InvalidateRect(SvgRectF rect)
+        { }
+
+        public void Render(ISvgElement node)
+        {
+            if (node is Dom.IElementVisitorTarget evt)
+            {
+                RenderElement(evt);
+            }
+        }
+
+        public void Render(ISvgDocument node)
+        {
+            RenderElement(node.RootElement);
+        }
+
+        private void RenderElement(Dom.IElementVisitorTarget element)
+        {
+            if (this.Canvas == null)
+                this.Canvas = new Canvas();
+            ShapeRenderingVisitor visitor = new ShapeRenderingVisitor(this);
+            element.Accept(visitor);
+        }
+    }
+}

--- a/Source/SharpVectorRenderingWpf/SharpVectors.Rendering.Wpf.csproj
+++ b/Source/SharpVectorRenderingWpf/SharpVectors.Rendering.Wpf.csproj
@@ -61,6 +61,10 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Shape\ShapeRenderingVisitor.cs" />
+    <Compile Include="Shape\UI\SvgShapeViewer.cs" />
+    <Compile Include="Shape\WpfHelper.cs" />
+    <Compile Include="Shape\WpfShapeRenderer.cs" />
     <Compile Include="Texts\WpfHorzTextRenderer.cs" />
     <Compile Include="Texts\WpfPathTextRenderer.cs" />
     <Compile Include="Texts\WpfTextAnchor.cs" />


### PR DESCRIPTION
I have added a separate renderer for WPF, which uses shapes to display svg elements. This allows styling using wpf styles, proper hit testing, tooltips, etc. I have tested with basic to moderate svg files and I haven't implemented all of the existing DOM elements and svg features. However, with some help from you and the community, I am sure it can reach 100% svg compliance. Furthermore, I believe the existing renderers can see code improvements if they take advantage of the element visitor.