### PR TITLE
Fixes RGBA HEx value conversion issue

### DIFF
--- a/Source/SharpVectorRenderingWpf/Utils/WpfConvert.cs
+++ b/Source/SharpVectorRenderingWpf/Utils/WpfConvert.cs
@@ -79,8 +79,7 @@ namespace SharpVectors.Renderers.Utils
             }
             if (color.HasAlpha)
             {
-                double dAlpha = color.Alpha.GetFloatValue(color.Alpha.PrimitiveType == CssPrimitiveType.Percentage ?
-                    CssPrimitiveType.Number : CssPrimitiveType.Percentage);
+                double dAlpha = color.Alpha.GetFloatValue(color.Alpha.PrimitiveType == CssPrimitiveType.Percentage ? CssPrimitiveType.Percentage : CssPrimitiveType.Number);
                 if (!double.IsNaN(dAlpha) && !double.IsInfinity(dAlpha))
                 {
                     return Color.FromArgb(Convert.ToByte(dAlpha), Convert.ToByte(dRed), 


### PR DESCRIPTION
Due to the swap of the CSSPrimitiveType enums, the color conversion for RGBA Hex values failed with an overflow exception