### PR TITLE
Fix for reinitialization of cloned objects @ EmbeddedBitmapSource.cs

### DIFF
--- a/Source/SharpVectorRuntimeWpf/EmbeddedBitmapSource.cs
+++ b/Source/SharpVectorRuntimeWpf/EmbeddedBitmapSource.cs
@@ -281,6 +281,7 @@ namespace SharpVectors.Runtime
         {
             this.BeginInit();
 
+            _stream = source._stream;
             _bitmap = source._bitmap;
 
             this.InitWicInfo(_bitmap);


### PR DESCRIPTION
Cloned objects have no value of `_stream` field.
So access to getter of any overrided property leads to call of `EnsureStream()` which in turn leads to unnecessary initialization of already initialized instance.
Story ends up with **InvalidOperationException** at `BitmapInitialize.BeginInit()` on `IsInitAtLeastOnce` property assert.