### PR TITLE
fix incorrect assembly file name when publishing as a single file

### DIFF
--- a/Source/SharpVectorCore/Utils/PathUtils.cs
+++ b/Source/SharpVectorCore/Utils/PathUtils.cs
@@ -40,7 +40,7 @@ namespace SharpVectors.Dom.Utils
 		private static string CombineInternal(string location, string[] paths)
 		{
 			var basePath = string.IsNullOrEmpty(location)
-				? AppDomain.CurrentDomain.BaseDirectory
+				? GetBaseDirectory()
 				: Path.GetDirectoryName(location);
 
 			if (paths.Length == 0)
@@ -61,10 +61,19 @@ namespace SharpVectors.Dom.Utils
 			if (!string.IsNullOrEmpty(location))
 				return location;
 
-			var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+			var baseDirectory = GetBaseDirectory();
 			var assemblyName = GetAssemblyFileName(assembly);
 
 			return Path.Combine(baseDirectory, assemblyName);
+		}
+
+		private static string GetBaseDirectory()
+		{
+#if NET5_0
+			return AppContext.BaseDirectory;
+#else
+			return AppDomain.CurrentDomain.BaseDirectory;
+#endif
 		}
 	}
 }

--- a/Source/SharpVectorCore/Utils/PathUtils.cs
+++ b/Source/SharpVectorCore/Utils/PathUtils.cs
@@ -32,7 +32,7 @@ namespace SharpVectors.Dom.Utils
 		/// <param name="assembly">An <see cref="Assembly"/> which is taken as the base path.</param>
 		/// <returns>A string containing the file name of the assembly.</returns>
 		public static string GetAssemblyFileName(Assembly assembly) =>
-			assembly.ManifestModule.Name;
+			assembly.ManifestModule.ScopeName;
 
 		/// <summary>
 		/// Exposes <see cref="Combine"/> for unit-testing where it is possible to mock an empty location

--- a/Source/SharpVectorCore/Utils/PathUtils.cs
+++ b/Source/SharpVectorCore/Utils/PathUtils.cs
@@ -69,7 +69,7 @@ namespace SharpVectors.Dom.Utils
 
 		private static string GetBaseDirectory()
 		{
-#if NET5_0
+#if NET50
 			return AppContext.BaseDirectory;
 #else
 			return AppDomain.CurrentDomain.BaseDirectory;

--- a/Source/SharpVectorCore/Utils/PathUtils.cs
+++ b/Source/SharpVectorCore/Utils/PathUtils.cs
@@ -75,7 +75,7 @@ namespace SharpVectors.Dom.Utils
 
 		private static string GetBaseDirectory()
 		{
-#if NET50
+#if NETCORE
 			return AppContext.BaseDirectory;
 #else
 			return AppDomain.CurrentDomain.BaseDirectory;

--- a/Source/SharpVectorCore/Utils/PathUtils.cs
+++ b/Source/SharpVectorCore/Utils/PathUtils.cs
@@ -15,24 +15,30 @@ namespace SharpVectors.Dom.Utils
 		/// <param name="assembly">An <see cref="Assembly"/> which is taken as the base path.</param>
 		/// <param name="paths">Path segments which are appended to the assembly location.</param>
 		/// <returns>A string containing the combined path.</returns>
-		public static string Combine(Assembly assembly, params string[] paths) =>
-			CombineInternal(assembly.Location, paths);
+		public static string Combine(Assembly assembly, params string[] paths)
+		{
+			return CombineInternal(assembly.Location, paths);
+		}
 
 		/// <summary>
 		/// Gets the full path to the assembly file.
 		/// </summary>
 		/// <param name="assembly">An <see cref="Assembly"/> which is taken as the base path.</param>
 		/// <returns>A string containing the full path to the assembly file.</returns>
-		public static string GetAssemblyPath(Assembly assembly) =>
-			GetAssemblyPathInternal(assembly, assembly.Location);
+		public static string GetAssemblyPath(Assembly assembly)
+		{
+			return GetAssemblyPathInternal(assembly, assembly.Location);
+		}
 
 		/// <summary>
 		/// Gets the file name if the assembly.
 		/// </summary>
 		/// <param name="assembly">An <see cref="Assembly"/> which is taken as the base path.</param>
 		/// <returns>A string containing the file name of the assembly.</returns>
-		public static string GetAssemblyFileName(Assembly assembly) =>
-			assembly.ManifestModule.ScopeName;
+		public static string GetAssemblyFileName(Assembly assembly)
+		{
+			return assembly.ManifestModule.ScopeName;
+		}
 
 		/// <summary>
 		/// Exposes <see cref="Combine"/> for unit-testing where it is possible to mock an empty location


### PR DESCRIPTION
Hopefully the final fix for #205 😅

- use `ScopeName` instead of `Name` (returns the same name as `assembly.Location` does)
- use `AppContext.BaseDirectory` for net5.0; use `AppDomain.CurrentDomain.BaseDirectory` for non .NET Core runtimes

Unit tests are still OK, tested WinForm and WPF apps - GetAssemblyPath returns the same string as `assembly.Location` does when an app is published not as a single-file