### PR TITLE
Fixed WpfW3cSvgTestSuite WebBrowser navigation error

### DIFF
--- a/Samples/WpfW3cSvgTestSuite/BrowserPage.xaml.cs
+++ b/Samples/WpfW3cSvgTestSuite/BrowserPage.xaml.cs
@@ -112,7 +112,7 @@ namespace WpfW3cSvgTestSuite
 
             try
             {
-                webBrowserBox.Navigate(svgFilePath);
+                webBrowserBox.Navigate(new Uri($"file:///{svgFilePath}"));
             }
             catch
             {


### PR DESCRIPTION
On my PC with Win10 x64, I put all open source projects cloned from GitHub into a folder `E:\开源项目`.

![File Path](https://user-images.githubusercontent.com/5435649/182007256-801d5220-62b3-4e0c-b731-31e636b72947.png)

As a result, the sample `WpfW3cSvgTestSuite` can not run as expected:

![动画](https://user-images.githubusercontent.com/5435649/182007346-b8dd9c1e-028d-4964-bcd4-07c7ed9d2eba.gif)


If the file path contains non-ASCII characters(CJK characters, for example), then

```csharp
    webBrowserBox.Navigate(svgFilePath);
```

will fail.

With this patch, issue resolved:

![动画2](https://user-images.githubusercontent.com/5435649/182007452-b13b003b-1b0c-4874-b949-7d6aa52ab803.gif)

##### References:

- [Navigate to uri with umlaut using wpf webbrowser control](https://stackoverflow.com/questions/39166451/navigate-to-uri-with-umlaut-using-wpf-webbrowser-control)
- [Load local HTML file in a C# WebBrowser](https://stackoverflow.com/questions/7194851/load-local-html-file-in-a-c-sharp-webbrowser)
