### PR TITLE
Ignore the use of external resources #229

### DIFF
--- a/Source/SharpVectorCore/IDocument.cs
+++ b/Source/SharpVectorCore/IDocument.cs
@@ -22,8 +22,10 @@ namespace SharpVectors.Dom
 		{
 			get;
 		}
-		
-		IElement CreateElement(string tagName);
+
+		bool CanAccessExternalResources(string resourcesUri);
+
+        IElement CreateElement(string tagName);
 		
 		IDocumentFragment CreateDocumentFragment();
 		

--- a/Source/SharpVectorCss/Css/CssXmlDocument.cs
+++ b/Source/SharpVectorCss/Css/CssXmlDocument.cs
@@ -271,6 +271,11 @@ namespace SharpVectors.Dom.Css
 
         public WebResponse GetResource(Uri absoluteUri)
         {
+            if (!CanAccessExternalResources(absoluteUri.ToString()))
+            {
+                return null;
+            }
+
             WebRequest request = new ExtendedHttpWebRequest(absoluteUri);
             WebResponse response = request.GetResponse();
 

--- a/Source/SharpVectorCss/Stylesheets/StyleSheet.cs
+++ b/Source/SharpVectorCss/Stylesheets/StyleSheet.cs
@@ -171,6 +171,13 @@ namespace SharpVectors.Dom.Stylesheets
             {
                 return;
             }
+
+            IDocument document = (OwnerNode.OwnerDocument) as IDocument;
+            if (document == null || !document.CanAccessExternalResources(absoluteUri.ToString()))
+            {
+                return;
+            }
+
             if (absoluteUri.IsAbsoluteUri && absoluteUri.IsFile)
             {
                 try

--- a/Source/SharpVectorDom/AccessExternalResourcesMode.cs
+++ b/Source/SharpVectorDom/AccessExternalResourcesMode.cs
@@ -1,0 +1,9 @@
+﻿namespace SharpVectors.Dom
+{
+    public enum AccessExternalResourcesMode
+    {
+        Allow,
+        Ignore,
+        ThrowError,
+    }
+}

--- a/Source/SharpVectorDom/Document.cs
+++ b/Source/SharpVectorDom/Document.cs
@@ -14,6 +14,8 @@ namespace SharpVectors.Dom
 
         private bool _mutationEvents;
         private EventTarget _eventTarget;
+        private AccessExternalResourcesMode _accessExternalResourcesMode;
+        private bool _canUseBitmap;
 
         #endregion
 
@@ -59,6 +61,30 @@ namespace SharpVectors.Dom
             }
             set {
                 _mutationEvents = value;
+            }
+        }
+
+        public AccessExternalResourcesMode AccessExternalResourcesMode
+        {
+            get
+            {
+                return _accessExternalResourcesMode;
+            }
+            set
+            {
+                _accessExternalResourcesMode = value;
+            }
+        }
+
+        public bool CanUseBitmap
+        {
+            get
+            {
+                return _canUseBitmap;
+            }
+            set
+            {
+                _canUseBitmap = value;
             }
         }
 
@@ -494,6 +520,26 @@ namespace SharpVectors.Dom
         #endregion
 
         #region IDocument interface
+
+        public bool CanAccessExternalResources(string resourcesUri)
+        {
+            if (AccessExternalResourcesMode == AccessExternalResourcesMode.Ignore)
+            {
+                return false;
+            }
+            
+            if (AccessExternalResourcesMode == AccessExternalResourcesMode.ThrowError)
+            {
+                if(resourcesUri == null)
+                {
+                    throw new InvalidOperationException("Unauthorized attempt to Access External Resources, resourcesUri = null");
+                }
+
+                throw new InvalidOperationException("Unauthorized attempt to Access External Resources, resourcesUri = " + resourcesUri);
+            }
+            
+            return true;
+        }
 
         IDocumentType IDocument.Doctype
         {

--- a/Source/SharpVectorModel/DocumentStructure/SvgDocument.cs
+++ b/Source/SharpVectorModel/DocumentStructure/SvgDocument.cs
@@ -866,8 +866,13 @@ namespace SharpVectors.Dom.Svg
 
                 //PrepareXmlResolver(settings);
 
+                if (!CanAccessExternalResources(absoluteUri.ToString()))
+                {
+                    return doc;
+                }
+
                 using (XmlReader reader = XmlReader.Create(GetResource(absoluteUri).GetResponseStream(),
-                    settings, absoluteUri.AbsolutePath))
+                        settings, absoluteUri.AbsolutePath))
                 {
                     doc.Load(reader);
                 }

--- a/Source/SharpVectorRenderingWpf/Utils/WpfSvgWindow.cs
+++ b/Source/SharpVectorRenderingWpf/Utils/WpfSvgWindow.cs
@@ -163,10 +163,16 @@ namespace SharpVectors.Renderers.Utils
             {
                 document.CustomSettings = _settings;
             }
-            if (drawingSettings != null && drawingSettings.DpiScale != null)
+            if (drawingSettings != null)
             {
-                var dpiScale = drawingSettings.DpiScale;
-                document.Dpi = dpiScale.PixelsPerInchY;
+                if (drawingSettings.DpiScale != null)
+                {
+                    var dpiScale = drawingSettings.DpiScale;
+                    document.Dpi = dpiScale.PixelsPerInchY;
+                }
+
+                document.AccessExternalResourcesMode = drawingSettings.AccessExternalResourcesMode;
+                document.CanUseBitmap = drawingSettings.CanUseBitmap;
             }
             document.Load(documentUri.AbsoluteUri);
 
@@ -199,10 +205,16 @@ namespace SharpVectors.Renderers.Utils
             {
                 document.CustomSettings = _settings;
             }
-            if (drawingSettings != null && drawingSettings.DpiScale != null)
+            if (drawingSettings != null)
             {
-                var dpiScale = drawingSettings.DpiScale;
-                document.Dpi = dpiScale.PixelsPerInchY;
+                if (drawingSettings.DpiScale != null)
+                {
+                    var dpiScale = drawingSettings.DpiScale;
+                    document.Dpi = dpiScale.PixelsPerInchY;
+                }
+
+                document.AccessExternalResourcesMode = drawingSettings.AccessExternalResourcesMode;
+                document.CanUseBitmap = drawingSettings.CanUseBitmap;
             }
             document.Load(documentStream);
 
@@ -223,10 +235,16 @@ namespace SharpVectors.Renderers.Utils
             {
                 document.CustomSettings = _settings;
             }
-            if (drawingSettings != null && drawingSettings.DpiScale != null)
+            if (drawingSettings != null)
             {
-                var dpiScale = drawingSettings.DpiScale;
-                document.Dpi = dpiScale.PixelsPerInchY;
+                if (drawingSettings.DpiScale != null)
+                {
+                    var dpiScale = drawingSettings.DpiScale;
+                    document.Dpi = dpiScale.PixelsPerInchY;
+                }
+
+                document.AccessExternalResourcesMode = drawingSettings.AccessExternalResourcesMode;
+                document.CanUseBitmap = drawingSettings.CanUseBitmap;
             }
             document.Load(textReader);
 
@@ -247,10 +265,16 @@ namespace SharpVectors.Renderers.Utils
             {
                 document.CustomSettings = _settings;
             }
-            if (drawingSettings != null && drawingSettings.DpiScale != null)
+            if (drawingSettings != null)
             {
-                var dpiScale = drawingSettings.DpiScale;
-                document.Dpi = dpiScale.PixelsPerInchY;
+                if (drawingSettings.DpiScale != null)
+                {
+                    var dpiScale = drawingSettings.DpiScale;
+                    document.Dpi = dpiScale.PixelsPerInchY;
+                }
+
+                document.AccessExternalResourcesMode = drawingSettings.AccessExternalResourcesMode;
+                document.CanUseBitmap = drawingSettings.CanUseBitmap;
             }
 
             document.Load(xmlReader);

--- a/Source/SharpVectorRenderingWpf/Wpf/WpfDrawingSettings.cs
+++ b/Source/SharpVectorRenderingWpf/Wpf/WpfDrawingSettings.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 
 using System.Windows;
 using System.Windows.Media;
+using SharpVectors.Dom;
 
 namespace SharpVectors.Renderers.Wpf
 {
@@ -80,6 +81,8 @@ namespace SharpVectors.Renderers.Wpf
         private SvgInteractiveModes _interactiveMode;
 
         private WpfDrawingResources _drawingResources;
+        private AccessExternalResourcesMode _accessMode;
+        private bool _canUseBitmap = true;
 
         #endregion
 
@@ -117,6 +120,8 @@ namespace SharpVectors.Renderers.Wpf
             _cssVariables          = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             _dpiScale              = DpiUtilities.GetSystemScale();
+            _accessMode            = AccessExternalResourcesMode.Allow;
+            _canUseBitmap          = true;
         }
 
         /// <summary>
@@ -161,6 +166,8 @@ namespace SharpVectors.Renderers.Wpf
             _fontFamilyMap         = settings._fontFamilyMap;
             _cssVariables          = settings._cssVariables;
             _dpiScale              = settings._dpiScale;
+            _accessMode            = settings._accessMode;
+            _canUseBitmap          = settings._canUseBitmap;
         }
 
         #endregion
@@ -687,6 +694,28 @@ namespace SharpVectors.Renderers.Wpf
                 {
                     _genericFantasy = value;
                 }
+            }
+        }
+
+        public AccessExternalResourcesMode AccessExternalResourcesMode
+        {
+            get {
+                return _accessMode;
+            }
+            set {
+                _accessMode = value;
+            }
+        }
+
+        public bool CanUseBitmap
+        {
+            get
+            {
+                return _canUseBitmap;
+            }
+            set
+            {
+                _canUseBitmap = value;
             }
         }
 

--- a/Source/SharpVectorRenderingWpf/Wpf/WpfImageRendering.cs
+++ b/Source/SharpVectorRenderingWpf/Wpf/WpfImageRendering.cs
@@ -515,10 +515,22 @@ namespace SharpVectors.Renderers.Wpf
                 return null;
             }
 
-            if (!element.Href.AnimVal.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+            SvgDocument ownerDocument = element.OwnerDocument;
+            if (!ownerDocument.CanUseBitmap)
             {
+                return null;
+            }
+
+            if (!element.Href.AnimVal.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+            {              
                 SvgUriReference svgUri = element.UriReference;
                 string absoluteUri = svgUri.AbsoluteUri;
+
+                if (ownerDocument != null && !ownerDocument.CanAccessExternalResources(absoluteUri))
+                {
+                    return null;
+                }
+
                 if (string.IsNullOrWhiteSpace(absoluteUri))
                 {
                     return null; // most likely, the image does not exist...


### PR DESCRIPTION
In addition to fixing #229, this pull request also adds a property to block uses of bitmaps to WpfDrawingSettings.CanUseBitmap